### PR TITLE
Parcel.get() performance gains (10x faster for indexed toArray()!)

### DIFF
--- a/packages/dataparcels/src/parcelData/convert26.js
+++ b/packages/dataparcels/src/parcelData/convert26.js
@@ -1,23 +1,11 @@
 // @flow
 
 // from http://bideowego.com/base-26-conversion
+// with optimisations
 
-function charRange(start: string, stop: string): string[] {
-    var result = [];
-
-    // get all chars from starting char
-    // to ending char
-    var i = start.charCodeAt(0),
-        last = stop.charCodeAt(0) + 1;
-    for (i; i < last; i++) {
-        result.push(String.fromCharCode(i));
-    }
-
-    return result;
-}
+let alpha = "abcdefghijklmnopqrstuvwxyz".split("");
 
 export function toInt26(str: string): number {
-    var alpha = charRange('a', 'z');
     var result = 0;
 
     // make sure we have a usable string
@@ -51,7 +39,6 @@ export function toInt26(str: string): number {
 }
 
 export function toString26(num: number): string {
-    var alpha = charRange('a', 'z');
     var result = '';
 
     // no letters for 0 or less

--- a/packages/dataparcels/src/parcelData/updateChild.js
+++ b/packages/dataparcels/src/parcelData/updateChild.js
@@ -28,10 +28,10 @@ export default () => (parcelData: ParcelData): ParcelData => {
         set('child', pipeWith(
             value,
             reduce(
-                (red, value, key) => pipeWith(
-                    red,
-                    set(key, child ? get(key, {})(child) : {})
-                ),
+                (red, value, key) => {
+                    red[key] = child ? get(key, {})(child) : {};
+                    return red;
+                },
                 pipeWith(
                     value,
                     shallowToJS(),

--- a/packages/dataparcels/src/parcelData/updateChildKeys.js
+++ b/packages/dataparcels/src/parcelData/updateChildKeys.js
@@ -4,7 +4,6 @@ import type {ParcelData} from '../types/Types';
 import {toString26, toInt26} from './convert26';
 
 import filter from 'unmutable/lib/filter';
-import get from 'unmutable/lib/get';
 import identity from 'unmutable/lib/identity';
 import map from 'unmutable/lib/map';
 import size from 'unmutable/lib/size';
@@ -44,10 +43,7 @@ export default () => (parcelData: ParcelData): ParcelData => {
     let keys = pipeWith(
         child,
         toArray(),
-        map(pipe(
-            get('key'),
-            toIntKey
-        ))
+        map(({key}) => toIntKey(key))
     );
 
     let highest = pipeWith(
@@ -58,12 +54,10 @@ export default () => (parcelData: ParcelData): ParcelData => {
 
     let updateChild = pipe(
         take(size()(value)),
-        map(
-            update('key', key => isKey(key)
-                ? key
-                : toStringKey(++highest)
-            )
-        )
+        map(({key, ...node}) => ({
+            key: isKey(key) ? key : toStringKey(++highest),
+            ...node
+        }))
     );
 
     return pipeWith(


### PR DESCRIPTION
- Improve performance of parcel.toArray() tenfold for indexed collections with 100 items
- Gains are more noticeable for higher numbers of items
- Affects `Parcel.get()`, `Parcel.getIn()`, `Parcel.toObject()` and `Parcel.toArray()` for indexed values.
- No breaking changes

## Unmutable performance gains identified

- Unmutable `identity()` is slow compared with an inline identity function like `_ => _` - will fix in unmutable.
- Unmutable `update()` is slower that it should be. It's performing needless type checking on items after the type is known - will fix in unmutable.
- Unmutable type checking takes a little time, only really noticeable in very tight loops. Perhaps there should be a `/perf/` version of each unmutable function that doesn't work with immutable.js, which you can use if you know you don't have immutable.js data? May not be worth it, really tight loops will always benefit from less abstraction anyway.
- Umutable `get()` should check arity to work out whether it needs to call `has()`