### PR TITLE
Feature/overload methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-# 📦 Dataparcels
+# Dataparcels
 
-A super declarative user input library that works really well with React.
+A library for editing data structures that works really well with React.
 
-*Almost done!*
 
-### [See the very very unfinished docs](https://blueflag.github.io/dataparcels)
+### [See the semi-unfinished docs](https://blueflag.github.io/dataparcels)
 
 ## Installation
 

--- a/packages/dataparcels-docs/package.json
+++ b/packages/dataparcels-docs/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "bruce": "^4.0.0",
-    "dcme-style": "^0.16.1",
+    "dcme-style": "^0.16.2",
     "gatsby": "^1.9.223",
     "gatsby-link": "^1.6.38",
     "gatsby-plugin-react-helmet": "^2.0.6",

--- a/packages/dataparcels-docs/src/docs/api/parcel/addDescendantModifier.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/addDescendantModifier.md
@@ -1,0 +1,9 @@
+```flow
+type ModifierFunction = Function;
+type ModifierObject = {
+    match?: string,
+    modifier: ModifierFunction
+};
+
+addDescendantModifier(modifier: ModifierFunction|ModifierObject): void
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/addModifier.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/addModifier.md
@@ -1,0 +1,9 @@
+```flow
+type ModifierFunction = Function;
+type ModifierObject = {
+    match?: string,
+    modifier: ModifierFunction
+};
+
+addModifier(modifier: ModifierFunction|ModifierObject): void
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/batch.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/batch.md
@@ -1,0 +1,3 @@
+```flow
+batch(batcher: Function): void
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/delete.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/delete.md
@@ -1,4 +1,4 @@
 ```flow
 delete(): void
-delete(key: string|number): void
+delete(key: string|number): void // only on ParentParcels, will delete a child
 ```

--- a/packages/dataparcels-docs/src/docs/api/parcel/delete.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/delete.md
@@ -1,0 +1,4 @@
+```flow
+delete(): void
+delete(key: string|number): void
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/deleteIn.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/deleteIn.md
@@ -1,3 +1,3 @@
 ```flow
-deleteIn(keyPath: Array<string|number>): void
+deleteIn(keyPath: Array<string|number>): void // only on ParentParcels
 ```

--- a/packages/dataparcels-docs/src/docs/api/parcel/deleteIn.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/deleteIn.md
@@ -1,0 +1,3 @@
+```flow
+deleteIn(keyPath: Array<string|number>): void
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/dispatch.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/dispatch.md
@@ -1,0 +1,3 @@
+```flow
+dispatch(dispatchable: Action|Action[]|ChangeRequest): void
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/get.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/get.md
@@ -1,8 +1,8 @@
 import IndexedKeys from 'docs/notes/IndexedKeys.md';
 
 ```flow
-get(key: string|number): Parcel
-get(key: string|number, notSetValue: any): Parcel
+get(key: string|number): Parcel // only on ParentParcels
+get(key: string|number, notSetValue: any): Parcel // only on ParentParcels
 ```
 
 Returns a Parcel containing the value associated with the provided key / index.

--- a/packages/dataparcels-docs/src/docs/api/parcel/getIn.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/getIn.md
@@ -1,6 +1,6 @@
 ```flow
-getIn(keyPath: Array<string|number>): Parcel
-getIn(keyPath: Array<string|number>, notSetValue: any): Parcel
+getIn(keyPath: Array<string|number>): Parcel // only on ParentParcels
+getIn(keyPath: Array<string|number>, notSetValue: any): Parcel // only on ParentParcels
 ```
 
 Returns a Parcel containing the value associated with the provided key path.

--- a/packages/dataparcels-docs/src/docs/api/parcel/getIn.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/getIn.md
@@ -1,0 +1,25 @@
+```flow
+getIn(keyPath: Array<string|number>): Parcel
+getIn(keyPath: Array<string|number>, notSetValue: any): Parcel
+```
+
+Returns a Parcel containing the value associated with the provided key path.
+If the key path doesn't exist, a Parcel with a value of `notSetValue` will be returned.
+If `notSetValue` is not provided then a Parcel with a value of 
+ `undefined` will be returned.
+ 
+```js
+let value = {
+    a: {
+        b: 123
+    }
+};
+let parcel = new Parcel({value});
+parcel.get(['a','b']).value; // returns 123
+parcel.get(['a','z']).value; // returns undefined
+parcel.get(['a','z'], 789).value; // returns 789
+```
+
+#### getIn() with indexed values
+
+...

--- a/packages/dataparcels-docs/src/docs/api/parcel/has.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/has.md
@@ -1,3 +1,3 @@
 ```flow
-has(key: string|number): boolean
+has(key: string|number): boolean // only on ParentParcels
 ```

--- a/packages/dataparcels-docs/src/docs/api/parcel/has.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/has.md
@@ -1,0 +1,3 @@
+```flow
+has(key: string|number): boolean
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/hasDispatched.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/hasDispatched.md
@@ -1,0 +1,3 @@
+```flow
+hasDispatched(): boolean
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/initialMeta.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/initialMeta.md
@@ -1,0 +1,3 @@
+```flow
+initialMeta(initialMeta: Object): void
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/insertAfter.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/insertAfter.md
@@ -1,0 +1,4 @@
+```flow
+insertAfter(value: *): void
+insertAfter(key: string|number, value: *): void
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/insertAfter.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/insertAfter.md
@@ -1,4 +1,4 @@
 ```flow
-insertAfter(value: *): void
-insertAfter(key: string|number, value: *): void
+insertAfter(value: *): void // only on ElementParcels, will insert after self
+insertAfter(key: string|number, value: *): void // only on IndexedParcels, will insert after child
 ```

--- a/packages/dataparcels-docs/src/docs/api/parcel/insertBefore.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/insertBefore.md
@@ -1,4 +1,4 @@
 ```flow
-insertBefore(value: *): void
-insertBefore(key: string|number, value: *): void
+insertBefore(value: *): void // only on ElementParcels, will insert before self
+insertBefore(key: string|number, value: *): void // only on IndexedParcels, will insert before child
 ```

--- a/packages/dataparcels-docs/src/docs/api/parcel/insertBefore.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/insertBefore.md
@@ -1,0 +1,4 @@
+```flow
+insertBefore(value: *): void
+insertBefore(key: string|number, value: *): void
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/isChild.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/isChild.md
@@ -1,0 +1,3 @@
+```flow
+isChild(): boolean
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/isElement.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/isElement.md
@@ -1,0 +1,3 @@
+```flow
+isElement(): boolean
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/isIndexed.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/isIndexed.md
@@ -1,0 +1,3 @@
+```flow
+isIndexed(): boolean
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/isParent.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/isParent.md
@@ -1,0 +1,3 @@
+```flow
+isParent(): boolean
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/isTopLevel.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/isTopLevel.md
@@ -1,0 +1,3 @@
+```flow
+isTopLevel(): boolean
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/modifyChange.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/modifyChange.md
@@ -1,0 +1,3 @@
+```flow
+modifyChange(batcher: Function): void
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/modifyChangeValue.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/modifyChangeValue.md
@@ -1,0 +1,4 @@
+```flow
+modifyChangeValue(updater: Function): void
+```
+

--- a/packages/dataparcels-docs/src/docs/api/parcel/modifyValue.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/modifyValue.md
@@ -1,0 +1,3 @@
+```flow
+modifyValue(updater: Function): void
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/onChange.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/onChange.md
@@ -1,0 +1,3 @@
+```flow
+onChange(value: *): void
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/onChangeDOM.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/onChangeDOM.md
@@ -1,0 +1,3 @@
+```flow
+onChangeDOM(event: Event): void
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/ping.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/ping.md
@@ -1,0 +1,3 @@
+```flow
+ping(): void
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/pipe.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/pipe.md
@@ -1,0 +1,3 @@
+```flow
+pipe(...updaters: Function[]): Parcel
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/pop.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/pop.md
@@ -1,3 +1,3 @@
 ```flow
-pop(): void
+pop(): void // only on IndexedParcels
 ```

--- a/packages/dataparcels-docs/src/docs/api/parcel/pop.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/pop.md
@@ -1,0 +1,3 @@
+```flow
+pop(): void
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/push.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/push.md
@@ -1,0 +1,3 @@
+```flow
+push(value: *): void
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/push.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/push.md
@@ -1,3 +1,3 @@
 ```flow
-push(value: *): void
+push(value: *): void // only on IndexedParcels
 ```

--- a/packages/dataparcels-docs/src/docs/api/parcel/set.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/set.md
@@ -1,4 +1,4 @@
 ```flow
 set(value: *): void
-set(key: string|number, value: *): void
+set(key: string|number, value: *): void // only on ParentParcels, will set a child
 ```

--- a/packages/dataparcels-docs/src/docs/api/parcel/set.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/set.md
@@ -1,0 +1,4 @@
+```flow
+set(value: *): void
+set(key: string|number, value: *): void
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/setChangeRequestMeta.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/setChangeRequestMeta.md
@@ -1,0 +1,3 @@
+```flow
+setChangeRequestMeta(meta: Object): void
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/setIn.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/setIn.md
@@ -1,3 +1,3 @@
 ```flow
-setIn(keyPath: Array<string|number>, value: *): void
+setIn(keyPath: Array<string|number>, value: *): void // only on ParentParcels
 ```

--- a/packages/dataparcels-docs/src/docs/api/parcel/setIn.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/setIn.md
@@ -1,0 +1,3 @@
+```flow
+setIn(keyPath: Array<string|number>, value: *): void
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/setMeta.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/setMeta.md
@@ -1,0 +1,3 @@
+```flow
+setMeta(partialMeta: Object): void
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/shift.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/shift.md
@@ -1,0 +1,3 @@
+```flow
+shift(): void
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/shift.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/shift.md
@@ -1,3 +1,3 @@
 ```flow
-shift(): void
+shift(): void // only on IndexedParcels
 ```

--- a/packages/dataparcels-docs/src/docs/api/parcel/size.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/size.md
@@ -1,3 +1,3 @@
 ```flow
-size(): number
+size(): number // only on ParentParcels
 ```

--- a/packages/dataparcels-docs/src/docs/api/parcel/size.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/size.md
@@ -1,0 +1,3 @@
+```flow
+size(): number
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/spread.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/spread.md
@@ -1,0 +1,3 @@
+```flow
+spread(): {value: *, onChange: Function}
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/spreadDOM.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/spreadDOM.md
@@ -1,0 +1,3 @@
+```flow
+spreadDOM(): {value: *, onChange: Function}
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/swap.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/swap.md
@@ -1,4 +1,4 @@
 ```flow
-swap(key: string|number): void
-swap(keyA: string|number, keyB: string|number): void
+swap(key: string|number): void // only on ElementParcels, will swap with sibling
+swap(keyA: string|number, keyB: string|number): void // only on IndexedParcels, will swap children
 ```

--- a/packages/dataparcels-docs/src/docs/api/parcel/swap.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/swap.md
@@ -1,0 +1,4 @@
+```flow
+swap(key: string|number): void
+swap(keyA: string|number, keyB: string|number): void
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/swapNext.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/swapNext.md
@@ -1,0 +1,4 @@
+```flow
+swapNext(): void
+swapNext(key: string|number): void
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/swapNext.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/swapNext.md
@@ -1,4 +1,4 @@
 ```flow
-swapNext(): void
-swapNext(key: string|number): void
+swapNext(): void // only on ElementParcels, will swap with next sibling
+swapNext(key: string|number): void // only on IndexedParcels, will swap child with next child
 ```

--- a/packages/dataparcels-docs/src/docs/api/parcel/swapPrev.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/swapPrev.md
@@ -1,0 +1,4 @@
+```flow
+swapPrev(): void
+swapPrev(key: string|number): void
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/swapPrev.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/swapPrev.md
@@ -1,4 +1,4 @@
 ```flow
-swapPrev(): void
-swapPrev(key: string|number): void
+swapPrev(): void // only on ElementParcels, will swap with previous sibling
+swapPrev(key: string|number): void // only on IndexedParcels, will swap child with previous child 
 ```

--- a/packages/dataparcels-docs/src/docs/api/parcel/toArray.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/toArray.md
@@ -1,3 +1,3 @@
 ```flow
-toArray(mapper?: Function): Parcel[]
+toArray(mapper?: Function): Parcel[] // only on ParentParcels
 ```

--- a/packages/dataparcels-docs/src/docs/api/parcel/toArray.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/toArray.md
@@ -1,0 +1,3 @@
+```flow
+toArray(mapper?: Function): Parcel[]
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/toObject.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/toObject.md
@@ -1,3 +1,3 @@
 ```flow
-toObject(mapper?: Function): Object
+toObject(mapper?: Function): Object // only on ParentParcels
 ```

--- a/packages/dataparcels-docs/src/docs/api/parcel/toObject.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/toObject.md
@@ -1,0 +1,3 @@
+```flow
+toObject(mapper?: Function): Object
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/unshift.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/unshift.md
@@ -1,3 +1,3 @@
 ```flow
-unshift(value: *): void
+unshift(value: *): void // only on IndexedParcels
 ```

--- a/packages/dataparcels-docs/src/docs/api/parcel/unshift.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/unshift.md
@@ -1,0 +1,3 @@
+```flow
+unshift(value: *): void
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/update.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/update.md
@@ -1,0 +1,4 @@
+```flow
+update(updater: Function): void
+update(key: string|number, updater: Function): void
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/update.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/update.md
@@ -1,4 +1,4 @@
 ```flow
 update(updater: Function): void
-update(key: string|number, updater: Function): void
+update(key: string|number, updater: Function): void // only on ParentParcels, will set a child
 ```

--- a/packages/dataparcels-docs/src/docs/api/parcel/updateIn.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/updateIn.md
@@ -1,3 +1,3 @@
 ```flow
-updateIn(keyPath: Array<string|number>, updater: Function): void
+updateIn(keyPath: Array<string|number>, updater: Function): void // only on ParentParcels
 ```

--- a/packages/dataparcels-docs/src/docs/api/parcel/updateIn.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/updateIn.md
@@ -1,0 +1,3 @@
+```flow
+updateIn(keyPath: Array<string|number>, updater: Function): void
+```

--- a/packages/dataparcels-docs/src/docs/api/parcel/updateMeta.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/updateMeta.md
@@ -1,0 +1,3 @@
+```flow
+updateMeta(updater: Function): void
+```

--- a/packages/dataparcels-docs/src/examples/EditingArrays.jsx
+++ b/packages/dataparcels-docs/src/examples/EditingArrays.jsx
@@ -18,10 +18,10 @@ const FruitListEditor = (props) => {
             return <PureParcel parcel={fruitParcel} key={fruitParcel.key}>
                 {(parcel) => <div>
                     <input type="text" {...parcel.spreadDOM()} />
-                    <button onClick={() => parcel.swapPrevWithSelf()}>^</button>
-                    <button onClick={() => parcel.swapNextWithSelf()}>v</button>
-                    <button onClick={() => parcel.insertAfterSelf(`${parcel.value} copy`)}>+</button>
-                    <button onClick={() => parcel.deleteSelf()}>x</button>
+                    <button onClick={() => parcel.swapPrev()}>^</button>
+                    <button onClick={() => parcel.swapNext()}>v</button>
+                    <button onClick={() => parcel.insertAfter(`${parcel.value} copy`)}>+</button>
+                    <button onClick={() => parcel.delete()}>x</button>
                 </div>}
             </PureParcel>;
         })}

--- a/packages/dataparcels-docs/src/examples/EditingArraysFlipMove.jsx
+++ b/packages/dataparcels-docs/src/examples/EditingArraysFlipMove.jsx
@@ -19,10 +19,10 @@ const FruitListEditor = (props) => {
             return <PureParcel parcel={fruitParcel} key={fruitParcel.key}>
                 {(parcel) => <div>
                     <input type="text" {...parcel.spreadDOM()} />
-                    <button onClick={() => parcel.swapPrevWithSelf()}>^</button>
-                    <button onClick={() => parcel.swapNextWithSelf()}>v</button>
-                    <button onClick={() => parcel.insertAfterSelf(`${parcel.value} copy`)}>+</button>
-                    <button onClick={() => parcel.deleteSelf()}>x</button>
+                    <button onClick={() => parcel.swapPrev()}>^</button>
+                    <button onClick={() => parcel.swapNext()}>v</button>
+                    <button onClick={() => parcel.insertAfter(`${parcel.value} copy`)}>+</button>
+                    <button onClick={() => parcel.delete()}>x</button>
                 </div>}
             </PureParcel>;
         })}

--- a/packages/dataparcels-docs/src/pages/api/Parcel.jsx
+++ b/packages/dataparcels-docs/src/pages/api/Parcel.jsx
@@ -40,6 +40,12 @@ import Markdown_swap from 'docs/api/parcel/swap.md';
 import Markdown_swapNext from 'docs/api/parcel/swapNext.md';
 import Markdown_swapPrev from 'docs/api/parcel/swapPrev.md';
 import Markdown_unshift from 'docs/api/parcel/unshift.md';
+import Markdown_modifyValue from 'docs/api/parcel/modifyValue.md';
+import Markdown_modifyChange from 'docs/api/parcel/modifyChange.md';
+import Markdown_modifyChangeValue from 'docs/api/parcel/modifyChangeValue.md';
+import Markdown_initialMeta from 'docs/api/parcel/initialMeta.md';
+import Markdown_addModifier from 'docs/api/parcel/addModifier.md';
+import Markdown_addDescendantModifier from 'docs/api/parcel/addDescendantModifier.md';
 import Markdown_isChild from 'docs/api/parcel/isChild.md';
 import Markdown_isElement from 'docs/api/parcel/isElement.md';
 import Markdown_isIndexed from 'docs/api/parcel/isIndexed.md';
@@ -87,6 +93,12 @@ const md = {
     swapNext: Markdown_swapNext,
     swapPrev: Markdown_swapPrev,
     unshift: Markdown_unshift,
+    modifyValue: Markdown_modifyValue,
+    modifyChange: Markdown_modifyChange,
+    modifyChangeValue: Markdown_modifyChangeValue,
+    initialMeta: Markdown_initialMeta,
+    addModifier: Markdown_addModifier,
+    addDescendantModifier: Markdown_addDescendantModifier,
     isChild: Markdown_isChild,
     isElement: Markdown_isElement,
     isIndexed: Markdown_isIndexed,

--- a/packages/dataparcels-docs/src/pages/api/Parcel.jsx
+++ b/packages/dataparcels-docs/src/pages/api/Parcel.jsx
@@ -9,17 +9,91 @@ import Markdown_data from 'docs/api/parcel/data.md';
 import Markdown_key from 'docs/api/parcel/key.md';
 import Markdown_id from 'docs/api/parcel/id.md';
 import Markdown_path from 'docs/api/parcel/path.md';
+import Markdown_spread from 'docs/api/parcel/spread.md';
+import Markdown_spreadDOM from 'docs/api/parcel/spreadDOM.md';
 import Markdown_get from 'docs/api/parcel/get.md';
+import Markdown_getIn from 'docs/api/parcel/getIn.md';
+import Markdown_toObject from 'docs/api/parcel/toObject.md';
+import Markdown_toArray from 'docs/api/parcel/toArray.md';
+import Markdown_has from 'docs/api/parcel/has.md';
+import Markdown_size from 'docs/api/parcel/size.md';
+import Markdown_onChange from 'docs/api/parcel/onChange.md';
+import Markdown_onChangeDOM from 'docs/api/parcel/onChangeDOM.md';
+import Markdown_set from 'docs/api/parcel/set.md';
+import Markdown_setIn from 'docs/api/parcel/setIn.md';
+import Markdown_update from 'docs/api/parcel/update.md';
+import Markdown_updateIn from 'docs/api/parcel/updateIn.md';
+import Markdown_delete from 'docs/api/parcel/delete.md';
+import Markdown_deleteIn from 'docs/api/parcel/deleteIn.md';
+import Markdown_setMeta from 'docs/api/parcel/setMeta.md';
+import Markdown_updateMeta from 'docs/api/parcel/updateMeta.md';
+import Markdown_setChangeRequestMeta from 'docs/api/parcel/setChangeRequestMeta.md';
+import Markdown_dispatch from 'docs/api/parcel/dispatch.md';
+import Markdown_batch from 'docs/api/parcel/batch.md';
+import Markdown_ping from 'docs/api/parcel/ping.md';
+import Markdown_insertAfter from 'docs/api/parcel/insertAfter.md';
+import Markdown_insertBefore from 'docs/api/parcel/insertBefore.md';
+import Markdown_pop from 'docs/api/parcel/pop.md';
+import Markdown_push from 'docs/api/parcel/push.md';
+import Markdown_shift from 'docs/api/parcel/shift.md';
+import Markdown_swap from 'docs/api/parcel/swap.md';
+import Markdown_swapNext from 'docs/api/parcel/swapNext.md';
+import Markdown_swapPrev from 'docs/api/parcel/swapPrev.md';
+import Markdown_unshift from 'docs/api/parcel/unshift.md';
+import Markdown_isChild from 'docs/api/parcel/isChild.md';
+import Markdown_isElement from 'docs/api/parcel/isElement.md';
+import Markdown_isIndexed from 'docs/api/parcel/isIndexed.md';
+import Markdown_isParent from 'docs/api/parcel/isParent.md';
+import Markdown_isTopLevel from 'docs/api/parcel/isTopLevel.md';
+import Markdown_hasDispatched from 'docs/api/parcel/hasDispatched.md';
+import Markdown_pipe from 'docs/api/parcel/pipe.md';
 
 const md = {
     _desc: Markdown_Parcel,
     value: Markdown_value,
     meta: Markdown_meta,
-    get: Markdown_get,
+    data: Markdown_data,
     key: Markdown_key,
     id: Markdown_id,
     path: Markdown_path,
-    data: Markdown_data
+    spread: Markdown_spread,
+    spreadDOM: Markdown_spreadDOM,
+    get: Markdown_get,
+    getIn: Markdown_getIn,
+    toObject: Markdown_toObject,
+    toArray: Markdown_toArray,
+    has: Markdown_has,
+    size: Markdown_size,
+    onChange: Markdown_onChange,
+    onChangeDOM: Markdown_onChangeDOM,
+    set: Markdown_set,
+    setIn: Markdown_setIn,
+    update: Markdown_update,
+    updateIn: Markdown_updateIn,
+    delete: Markdown_delete,
+    deleteIn: Markdown_deleteIn,
+    setMeta: Markdown_setMeta,
+    updateMeta: Markdown_updateMeta,
+    setChangeRequestMeta: Markdown_setChangeRequestMeta,
+    dispatch: Markdown_dispatch,
+    batch: Markdown_batch,
+    ping: Markdown_ping,
+    insertAfter: Markdown_insertAfter,
+    insertBefore: Markdown_insertBefore,
+    pop: Markdown_pop,
+    push: Markdown_push,
+    shift: Markdown_shift,
+    swap: Markdown_swap,
+    swapNext: Markdown_swapNext,
+    swapPrev: Markdown_swapPrev,
+    unshift: Markdown_unshift,
+    isChild: Markdown_isChild,
+    isElement: Markdown_isElement,
+    isIndexed: Markdown_isIndexed,
+    isParent: Markdown_isParent,
+    isTopLevel: Markdown_isTopLevel,
+    hasDispatched: Markdown_hasDispatched,
+    pipe: Markdown_pipe
 }
 
 const api = `
@@ -53,6 +127,7 @@ setIn()
 update()
 updateIn()
 delete()
+deleteIn()
 
 # Advanced change methods
 setMeta()

--- a/packages/dataparcels-docs/src/pages/api/Parcel.jsx
+++ b/packages/dataparcels-docs/src/pages/api/Parcel.jsx
@@ -35,14 +35,26 @@ path
 spread()
 spreadDOM()
 
-# Composition methods
-pipe()
+# Branch methods
+get()
+getIn()
+toObject()
+toArray()
+
+# Parent methods
+has()
+size()
 
 # Change methods
 onChange()
 onChangeDOM()
-setSelf()
-updateSelf()
+set()
+setIn()
+update()
+updateIn()
+delete()
+
+# Advanced change methods
 setMeta()
 updateMeta()
 setChangeRequestMeta()
@@ -50,22 +62,7 @@ dispatch()
 batch()
 ping()
 
-# Parent get methods
-get()
-getIn()
-toObject()
-toArray()
-has()
-size()
-
-# Parent change methods
-set()
-setIn()
-update()
-updateIn()
-
-# Indexed change methods
-delete()
+# Indexed & element change methods
 insertAfter()
 insertBefore()
 push()
@@ -75,16 +72,6 @@ swap()
 swapNext()
 swapPrev()
 unshift()
-
-# Child change methods
-deleteSelf()
-
-# Element change methods
-insertAfterSelf()
-insertBeforeSelf()
-swapWithSelf()
-swapNextWithSelf()
-swapPrevWithSelf()
 
 # Modify methods
 modifyValue()
@@ -103,6 +90,9 @@ isTopLevel()
 
 # Status methods
 hasDispatched()
+
+# Composition methods
+pipe()
 
 `;
 

--- a/packages/dataparcels-docs/src/pages/examples/editing-arrays.md
+++ b/packages/dataparcels-docs/src/pages/examples/editing-arrays.md
@@ -27,10 +27,10 @@ const FruitListEditor = (props) => {
             return <PureParcel parcel={fruitParcel} key={fruitParcel.key}>
                 {(parcel) => <div>
                     <input type="text" {...parcel.spreadDOM()} />
-                    <button onClick={() => parcel.swapPrevWithSelf()}>^</button>
-                    <button onClick={() => parcel.swapNextWithSelf()}>v</button>
-                    <button onClick={() => parcel.insertAfterSelf(`${parcel.value} copy`)}>+</button>
-                    <button onClick={() => parcel.deleteSelf()}>x</button>
+                    <button onClick={() => parcel.swapPrev()}>^</button>
+                    <button onClick={() => parcel.swapNext()}>v</button>
+                    <button onClick={() => parcel.insertAfter(`${parcel.value} copy`)}>+</button>
+                    <button onClick={() => parcel.delete()}>x</button>
                 </div>}
             </PureParcel>;
         })}
@@ -69,10 +69,10 @@ const FruitListEditor = (props) => {
             return <PureParcel parcel={fruitParcel} key={fruitParcel.key}>
                 {(parcel) => <div>
                     <input type="text" {...parcel.spreadDOM()} />
-                    <button onClick={() => parcel.swapPrevWithSelf()}>^</button>
-                    <button onClick={() => parcel.swapNextWithSelf()}>v</button>
-                    <button onClick={() => parcel.insertAfterSelf(`${parcel.value} copy`)}>+</button>
-                    <button onClick={() => parcel.deleteSelf()}>x</button>
+                    <button onClick={() => parcel.swapPrev()}>^</button>
+                    <button onClick={() => parcel.swapNext()}>v</button>
+                    <button onClick={() => parcel.insertAfter(`${parcel.value} copy`)}>+</button>
+                    <button onClick={() => parcel.delete()}>x</button>
                 </div>}
             </PureParcel>;
         })}

--- a/packages/dataparcels-docs/src/pages/index.js
+++ b/packages/dataparcels-docs/src/pages/index.js
@@ -15,7 +15,7 @@ export default () => <Box>
                         top={() => <Text element="h1" modifier="sizeTera superDuper">dataparcels</Text>}
                         bottom={() => <Box>
                             <Text element="p" modifier="monospace margin">A library for editing data structures that works really well with React.</Text>
-                            <Text element="p" modifier="monospace"><a className="Link" href="https://github.com/blueflag/dataparcels">github</a> | <a className="Link" href="https://www.npmjs.com/package/dataparcels">npm</a></Text>
+                            <Text element="p" modifier="monospace"><a className="Link" href="https://github.com/blueflag/dataparcels">github</a></Text>
                         </Box>}
                     />
                 </GridItem>

--- a/packages/dataparcels/README.md
+++ b/packages/dataparcels/README.md
@@ -1,10 +1,9 @@
-# 📦 Dataparcels
+# Dataparcels
 
-A super declarative user input library that works really well with React.
+A library for editing data structures that works really well with React.
 
-*Almost done!*
 
-### [See the very very unfinished docs](https://blueflag.github.io/dataparcels)
+### [See the semi-unfinished docs](https://blueflag.github.io/dataparcels)
 
 ## Installation
 

--- a/packages/dataparcels/src/change/ActionCreators.js
+++ b/packages/dataparcels/src/change/ActionCreators.js
@@ -5,7 +5,7 @@ import type {
 } from '../types/Types';
 import Action from './Action';
 
-const dangerouslyReplaceSelf: Function = (value: *): Action => {
+const dangerouslyReplace: Function = (value: *): Action => {
     return new Action({
         type: "replace",
         payload: {
@@ -165,7 +165,7 @@ const unshift: Function = (value: *): Action => {
 };
 
 export default {
-    dangerouslyReplaceSelf,
+    dangerouslyReplace,
     delete: del,
     deleteSelf,
     insertAfter,

--- a/packages/dataparcels/src/change/ActionCreators.js
+++ b/packages/dataparcels/src/change/ActionCreators.js
@@ -127,7 +127,7 @@ const swapNext: Function = (key: Key|Index): Action => {
     });
 };
 
-const swapNextWithSelf: Function = (): Action => {
+const swapNextSelf: Function = (): Action => {
     return new Action({
         type: "swapNext"
     });
@@ -140,13 +140,13 @@ const swapPrev: Function = (key: Key|Index): Action => {
     });
 };
 
-const swapPrevWithSelf: Function = (): Action => {
+const swapPrevSelf: Function = (): Action => {
     return new Action({
         type: "swapPrev"
     });
 };
 
-const swapWithSelf: Function = (keyB: Key|Index): Action => {
+const swapSelf: Function = (keyB: Key|Index): Action => {
     return new Action({
         type: "swap",
         payload: {
@@ -180,9 +180,9 @@ export default {
     shift,
     swap,
     swapNext,
-    swapNextWithSelf,
+    swapNextSelf,
     swapPrev,
-    swapPrevWithSelf,
-    swapWithSelf,
+    swapPrevSelf,
+    swapSelf,
     unshift
 };

--- a/packages/dataparcels/src/parcel/Parcel.js
+++ b/packages/dataparcels/src/parcel/Parcel.js
@@ -277,6 +277,7 @@ export default class Parcel {
         ["0"]: () => this._methods.deleteSelf(),
         ["1"]: (key: Key|Index) => this._methods.delete(key)
     });
+    deleteIn = (keyPath: Array<Key|Index>) => this._methods.deleteIn(keyPath);
 
     // Advanced change methods
     setMeta = (partialMeta: ParcelMeta) => this._methods.setMeta(partialMeta);

--- a/packages/dataparcels/src/parcel/Parcel.js
+++ b/packages/dataparcels/src/parcel/Parcel.js
@@ -35,6 +35,8 @@ import ParcelTypes from './ParcelTypes';
 import ParcelId from '../parcelId/ParcelId';
 import Treeshare from '../treeshare/Treeshare';
 
+import overload from 'unmutable/lib/util/overload';
+
 const DEFAULT_CONFIG_INTERNAL = () => ({
     onDispatch: undefined,
     child: undefined,
@@ -245,60 +247,68 @@ export default class Parcel {
     spread = (): * => this._methods.spread();
     spreadDOM = (): * => this._methods.spreadDOM();
 
-    // Composition methods
-    pipe = (...updaters: Function[]): Parcel => this._methods.pipe(...updaters);
+    // Branch methods
+    get = (key: Key|Index, notFoundValue: ?* = undefined): Parcel => this._methods.get(key, notFoundValue);
+    getIn = (keyPath: Array<Key|Index>, notFoundValue: ?* = undefined): Parcel => this._methods.getIn(keyPath, notFoundValue);
+    toObject = (mapper: ParcelMapper = _ => _): { [key: string]: * } => this._methods.toObject(mapper);
+    toArray = (mapper: ParcelMapper = _ => _): Array<*> => this._methods.toArray(mapper);
+
+    // Parent methods
+    has = (key: Key|Index): boolean => this._methods.has(key);
+    size = (): number => this._methods.size();
 
     // Status methods
     hasDispatched = (): boolean => this._methods.hasDispatched();
 
     // Change methods
-    setSelf = (value: *) => this._methods.setSelf(value);
-    updateSelf = (updater: Function) => this._methods.updateSelf(updater);
     onChange = (value: *) => this._methods.onChange(value);
     onChangeDOM = (event: *) => this._methods.onChangeDOM(event);
+    set = overload({
+        ["1"]: (value: *) => this._methods.setSelf(value),
+        ["2"]: (key: Key|Index, value: *) => this._methods.set(key, value)
+    });
+    update = overload({
+        ["1"]: (updater: ParcelValueUpdater) => this._methods.updateSelf(updater),
+        ["2"]: (key: Key|Index, updater: ParcelValueUpdater) => this._methods.update(key, updater)
+    });
+    setIn = (keyPath: Array<Key|Index>, value: *) => this._methods.setIn(keyPath, value);
+    updateIn = (keyPath: Array<Key|Index>, updater: ParcelValueUpdater) => this._methods.updateIn(keyPath, updater);
+    delete = overload({
+        ["0"]: () => this._methods.deleteSelf(),
+        ["1"]: (key: Key|Index) => this._methods.delete(key)
+    });
+
+    // Advanced change methods
     setMeta = (partialMeta: ParcelMeta) => this._methods.setMeta(partialMeta);
     updateMeta = (updater: ParcelMetaUpdater) => this._methods.updateMeta(updater);
     setChangeRequestMeta = (partialMeta: ParcelMeta) => this._methods.setChangeRequestMeta(partialMeta);
     dispatch = (dispatchable: Action|Action[]|ChangeRequest) => this._methods.dispatch(dispatchable);
     batch = (batcher: ParcelBatcher, changeRequest: ?ChangeRequest) => this._methods.batch(batcher, changeRequest);
     ping = () => this._methods.ping();
-    dangerouslyReplaceSelf = (value: *) => this._methods.dangerouslyReplaceSelf(value);
-
-    // Parent get methods
-    has = (key: Key|Index): boolean => this._methods.has(key);
-    get = (key: Key|Index, notFoundValue: ?* = undefined): Parcel => this._methods.get(key, notFoundValue);
-    getIn = (keyPath: Array<Key|Index>, notFoundValue: ?* = undefined): Parcel => this._methods.getIn(keyPath, notFoundValue);
-    toObject = (mapper: ParcelMapper = _ => _): { [key: string]: * } => this._methods.toObject(mapper);
-    toArray = (mapper: ParcelMapper = _ => _): Array<*> => this._methods.toArray(mapper);
-    size = (): number => this._methods.size();
-
-    // Parent change methods
-    set = (key: Key|Index, value: *) => this._methods.set(key, value);
-    update = (key: Key|Index, updater: ParcelValueUpdater) => this._methods.update(key, updater);
-    setIn = (keyPath: Array<Key|Index>, value: *) => this._methods.setIn(keyPath, value);
-    updateIn = (keyPath: Array<Key|Index>, updater: ParcelValueUpdater) => this._methods.updateIn(keyPath, updater);
+    dangerouslyReplace = (value: *) => this._methods.dangerouslyReplace(value);
 
     // Indexed methods
-    delete = (key: Key|Index) => this._methods.delete(key);
-    insertAfter = (key: Key|Index, value: *) => this._methods.insertAfter(key, value);
-    insertBefore = (key: Key|Index, value: *) => this._methods.insertBefore(key, value);
+    insertAfter = overload({
+        ["1"]: (value: *) => this._methods.insertAfterSelf(value),
+        ["2"]: (key: Key|Index, value: *) => this._methods.insertAfter(key, value)
+    });
+    insertBefore = overload({
+        ["1"]: (value: *) => this._methods.insertBeforeSelf(value),
+        ["2"]: (key: Key|Index, value: *) => this._methods.insertBefore(key, value)
+    });
     push = (value: *) => this._methods.push(value);
     pop = () => this._methods.pop();
     shift = () => this._methods.shift();
     swap = (keyA: Key|Index, keyB: Key|Index) => this._methods.swap(keyA, keyB);
-    swapNext = (key: Key|Index) => this._methods.swapNext(key);
-    swapPrev = (key: Key|Index) => this._methods.swapPrev(key);
+    swapNext = overload({
+        ["0"]: () => this._methods.swapNextWithSelf(),
+        ["1"]: (key: Key|Index) => this._methods.swapNext(key)
+    });
+    swapPrev = overload({
+        ["0"]: () => this._methods.swapPrevWithSelf(),
+        ["1"]: (key: Key|Index) => this._methods.swapPrev(key)
+    });
     unshift = (value: *) => this._methods.unshift(value);
-
-    // Child methods
-    deleteSelf = () => this._methods.deleteSelf();
-
-    // Element methods
-    insertAfterSelf = (value: *) => this._methods.insertAfterSelf(value);
-    insertBeforeSelf = (value: *) => this._methods.insertBeforeSelf(value);
-    swapNextWithSelf = () => this._methods.swapNextWithSelf();
-    swapPrevWithSelf = () => this._methods.swapPrevWithSelf();
-    swapWithSelf = (key: Key|Index) => this._methods.swapWithSelf(key);
 
     // Modify methods
     modifyValue = (updater: Function): Parcel => this._methods.modifyValue(updater);
@@ -314,6 +324,9 @@ export default class Parcel {
     isIndexed = (): boolean => this._parcelTypes.isIndexed();
     isParent = (): boolean => this._parcelTypes.isParent();
     isTopLevel = (): boolean => this._parcelTypes.isTopLevel();
+
+    // Composition methods
+    pipe = (...updaters: Function[]): Parcel => this._methods.pipe(...updaters);
 
     // Advanced methods
     getInternalLocationShareData = (): * => this._methods.getInternalLocationShareData();

--- a/packages/dataparcels/src/parcel/Parcel.js
+++ b/packages/dataparcels/src/parcel/Parcel.js
@@ -301,15 +301,15 @@ export default class Parcel {
     pop = () => this._methods.pop();
     shift = () => this._methods.shift();
     swap = overload({
-        ["1"]: (key: Key|Index) => this._methods.swapWithSelf(key),
+        ["1"]: (key: Key|Index) => this._methods.swapSelf(key),
         ["2"]: (keyA: Key|Index, keyB: Key|Index) => this._methods.swap(keyA, keyB)
     });
     swapNext = overload({
-        ["0"]: () => this._methods.swapNextWithSelf(),
+        ["0"]: () => this._methods.swapNextSelf(),
         ["1"]: (key: Key|Index) => this._methods.swapNext(key)
     });
     swapPrev = overload({
-        ["0"]: () => this._methods.swapPrevWithSelf(),
+        ["0"]: () => this._methods.swapPrevSelf(),
         ["1"]: (key: Key|Index) => this._methods.swapPrev(key)
     });
     unshift = (value: *) => this._methods.unshift(value);

--- a/packages/dataparcels/src/parcel/Parcel.js
+++ b/packages/dataparcels/src/parcel/Parcel.js
@@ -299,7 +299,10 @@ export default class Parcel {
     push = (value: *) => this._methods.push(value);
     pop = () => this._methods.pop();
     shift = () => this._methods.shift();
-    swap = (keyA: Key|Index, keyB: Key|Index) => this._methods.swap(keyA, keyB);
+    swap = overload({
+        ["1"]: (key: Key|Index) => this._methods.swapWithSelf(key),
+        ["2"]: (keyA: Key|Index, keyB: Key|Index) => this._methods.swap(keyA, keyB)
+    });
     swapNext = overload({
         ["0"]: () => this._methods.swapNextWithSelf(),
         ["1"]: (key: Key|Index) => this._methods.swapNext(key)

--- a/packages/dataparcels/src/parcel/__test__/ChildParcelMethods-test.js
+++ b/packages/dataparcels/src/parcel/__test__/ChildParcelMethods-test.js
@@ -1,7 +1,7 @@
 // @flow
 import Parcel from '../Parcel';
 
-test('ChildParcel.deleteSelf() should delete self', () => {
+test('ChildParcel.delete() should delete self', () => {
     expect.assertions(1);
 
     var expectedValue = {
@@ -19,10 +19,10 @@ test('ChildParcel.deleteSelf() should delete self', () => {
         }
     };
 
-    new Parcel(data).get('a').deleteSelf();
+    new Parcel(data).get('a').delete();
 });
 
-test('ChildParcel.deleteSelf() should delete self when indexed', () => {
+test('ChildParcel.delete() should delete self when indexed', () => {
     expect.assertions(1);
 
     var expectedValue = [1,3];
@@ -35,5 +35,5 @@ test('ChildParcel.deleteSelf() should delete self when indexed', () => {
         }
     };
 
-    new Parcel(data).get('#b').deleteSelf();
+    new Parcel(data).get('#b').delete();
 });

--- a/packages/dataparcels/src/parcel/__test__/ElementParcelMethods-test.js
+++ b/packages/dataparcels/src/parcel/__test__/ElementParcelMethods-test.js
@@ -1,7 +1,7 @@
 // @flow
 import Parcel from '../Parcel';
 
-test('ElementParcel.insertBeforeSelf() should insert', () => {
+test('ElementParcel.insertBefore() should insert', () => {
     expect.assertions(4);
 
     var data = {
@@ -41,7 +41,7 @@ test('ElementParcel.insertBeforeSelf() should insert', () => {
         }
     })
         .get(1)
-        .insertBeforeSelf(4);
+        .insertBefore(4);
 
     new Parcel({
         ...data,
@@ -51,10 +51,10 @@ test('ElementParcel.insertBeforeSelf() should insert', () => {
         }
     })
         .get("#b")
-        .insertBeforeSelf(4);
+        .insertBefore(4);
 });
 
-test('ElementParcel.insertAfterSelf() should insert', () => {
+test('ElementParcel.insertAfter() should insert', () => {
     expect.assertions(4);
 
     var data = {
@@ -94,7 +94,7 @@ test('ElementParcel.insertAfterSelf() should insert', () => {
         }
     })
         .get(1)
-        .insertAfterSelf(4);
+        .insertAfter(4);
 
     new Parcel({
         ...data,
@@ -104,10 +104,10 @@ test('ElementParcel.insertAfterSelf() should insert', () => {
         }
     })
         .get("#b")
-        .insertAfterSelf(4);
+        .insertAfter(4);
 });
 
-test('ElementParcel.swapWithSelf() should swap', () => {
+test('ElementParcel.swap() should swap', () => {
     expect.assertions(2);
 
     var data = {
@@ -146,10 +146,10 @@ test('ElementParcel.swapWithSelf() should swap', () => {
         }
     })
         .get(0)
-        .swapWithSelf(2);
+        .swap(2);
 });
 
-test('ElementParcel.swapNextWithSelf() should swapNext', () => {
+test('ElementParcel.swapNext() should swapNext', () => {
     expect.assertions(4);
 
     var data = {
@@ -186,7 +186,7 @@ test('ElementParcel.swapNextWithSelf() should swapNext', () => {
         }
     })
         .get(0)
-        .swapNextWithSelf();
+        .swapNext();
 
     expectedAction = {
         type: "swapNext",
@@ -204,7 +204,7 @@ test('ElementParcel.swapNextWithSelf() should swapNext', () => {
 });
 
 
-test('ElementParcel.swapPrevWithSelf() should swapPrev', () => {
+test('ElementParcel.swapPrev() should swapPrev', () => {
     expect.assertions(2);
 
     var data = {
@@ -241,5 +241,5 @@ test('ElementParcel.swapPrevWithSelf() should swapPrev', () => {
         }
     })
         .get("#b")
-        .swapPrevWithSelf();
+        .swapPrev();
 });

--- a/packages/dataparcels/src/parcel/__test__/ModifyMethods-test.js
+++ b/packages/dataparcels/src/parcel/__test__/ModifyMethods-test.js
@@ -37,7 +37,7 @@ test('Parcel.modifyChange() should allow you to change the payload of a changed 
 
     new Parcel(data)
         .modifyChange((parcel: Parcel, changeRequest: ChangeRequest) => {
-            parcel.setSelf(changeRequest.data.value + 1);
+            parcel.set(changeRequest.data.value + 1);
         })
         .onChange(456);
 });

--- a/packages/dataparcels/src/parcel/__test__/ParcelChangeMethods-test.js
+++ b/packages/dataparcels/src/parcel/__test__/ParcelChangeMethods-test.js
@@ -1,7 +1,7 @@
 // @flow
 import Parcel from '../Parcel';
 
-test('Parcel.setSelf() should call the Parcels handleChange function with the new parcelData', () => {
+test('Parcel.set() should call the Parcels handleChange function with the new parcelData', () => {
     expect.assertions(3);
 
     var data = {
@@ -30,10 +30,10 @@ test('Parcel.setSelf() should call the Parcels handleChange function with the ne
             expect(expectedData).toEqual(changeRequest.data);
             expect(expectedAction).toEqual(changeRequest.actions()[0].toJS());
         }
-    }).setSelf(456);
+    }).set(456);
 });
 
-test('Parcel.updateSelf() should call the Parcels handleChange function with the new parcelData', () => {
+test('Parcel.update() should call the Parcels handleChange function with the new parcelData', () => {
     expect.assertions(3);
 
     var data = {
@@ -63,7 +63,7 @@ test('Parcel.updateSelf() should call the Parcels handleChange function with the
             expect(expectedData).toEqual(parcel.data);
             expect(expectedAction).toEqual(changeRequest.actions()[0].toJS());
         }
-    }).updateSelf((ii) => {
+    }).update((ii) => {
         expect(expectedArg).toEqual(ii);
         return 456;
     });

--- a/packages/dataparcels/src/parcel/__test__/ParcelTypes-test.js
+++ b/packages/dataparcels/src/parcel/__test__/ParcelTypes-test.js
@@ -136,8 +136,8 @@ test('Correct methods are created for primitive values', () => {
     expect(() => new Parcel(data).value).not.toThrow();
     expect(() => new Parcel(data).has('a')).toThrowError(`.has() is not a function.`);
     expect(() => new Parcel(data).pop()).toThrowError(`.pop() is not a function.`);
-    expect(() => new Parcel(data).deleteSelf()).toThrowError(`.deleteSelf() is not a function.`);
-    expect(() => new Parcel(data).swapNextWithSelf()).toThrowError(`.swapNextWithSelf() is not a function.`);
+    expect(() => new Parcel(data).delete()).toThrowError(`.delete() is not a function.`);
+    expect(() => new Parcel(data).swapNext()).toThrowError(`.swapNext() is not a function.`);
 });
 
 test('Correct methods are created for object values', () => {
@@ -147,8 +147,8 @@ test('Correct methods are created for object values', () => {
     expect(() => new Parcel(data).value).not.toThrow();
     expect(() => new Parcel(data).has('a')).not.toThrow();
     expect(() => new Parcel(data).pop()).toThrowError(`.pop() is not a function.`);
-    expect(() => new Parcel(data).deleteSelf()).toThrowError(`.deleteSelf() is not a function.`);
-    expect(() => new Parcel(data).swapNextWithSelf()).toThrowError(`.swapNextWithSelf() is not a function.`);
+    expect(() => new Parcel(data).delete()).toThrowError(`.delete() is not a function.`);
+    expect(() => new Parcel(data).swapNext()).toThrowError(`.swapNext() is not a function.`);
 });
 
 test('Correct methods are created for array values', () => {
@@ -158,8 +158,8 @@ test('Correct methods are created for array values', () => {
     expect(() => new Parcel(data).value).not.toThrow();
     expect(() => new Parcel(data).has('a')).not.toThrow();
     expect(() => new Parcel(data).pop()).not.toThrow();
-    expect(() => new Parcel(data).deleteSelf()).toThrowError(`.deleteSelf() is not a function.`);
-    expect(() => new Parcel(data).swapNextWithSelf()).toThrowError(`.swapNextWithSelf() is not a function.`);
+    expect(() => new Parcel(data).delete()).toThrowError(`.delete() is not a function.`);
+    expect(() => new Parcel(data).swapNext()).toThrowError(`.swapNext() is not a function.`);
 });
 
 test('Correct methods are created for object child values', () => {
@@ -169,8 +169,8 @@ test('Correct methods are created for object child values', () => {
     expect(() => new Parcel(data).get("a").value).not.toThrow();
     expect(() => new Parcel(data).get("a").has('a')).toThrowError(`.has() is not a function.`);
     expect(() => new Parcel(data).get("a").pop()).toThrowError(`.pop() is not a function.`);
-    expect(() => new Parcel(data).get("a").deleteSelf()).not.toThrow();
-    expect(() => new Parcel(data).get("a").swapNextWithSelf()).toThrowError(`.swapNextWithSelf() is not a function.`);
+    expect(() => new Parcel(data).get("a").delete()).not.toThrow();
+    expect(() => new Parcel(data).get("a").swapNext()).toThrowError(`.swapNext() is not a function.`);
 });
 
 test('Correct methods are created for array element values', () => {
@@ -180,7 +180,7 @@ test('Correct methods are created for array element values', () => {
     expect(() => new Parcel(data).get(0).value).not.toThrow();
     expect(() => new Parcel(data).get(0).has('a')).toThrowError(`.has() is not a function.`);
     expect(() => new Parcel(data).get(0).pop()).toThrowError(`.pop() is not a function.`);
-    expect(() => new Parcel(data).get(0).deleteSelf()).not.toThrow();
-    expect(() => new Parcel(data).get(0).swapNextWithSelf()).not.toThrow();
+    expect(() => new Parcel(data).get(0).delete()).not.toThrow();
+    expect(() => new Parcel(data).get(0).swapNext()).not.toThrow();
 });
 

--- a/packages/dataparcels/src/parcel/__test__/ParcelTypes-test.js
+++ b/packages/dataparcels/src/parcel/__test__/ParcelTypes-test.js
@@ -136,8 +136,8 @@ test('Correct methods are created for primitive values', () => {
     expect(() => new Parcel(data).value).not.toThrow();
     expect(() => new Parcel(data).has('a')).toThrowError(`.has() is not a function.`);
     expect(() => new Parcel(data).pop()).toThrowError(`.pop() is not a function.`);
-    expect(() => new Parcel(data).delete()).toThrowError(`.deleteSelf() is not a function.`);
-    expect(() => new Parcel(data).swapNext()).toThrowError(`.swapNextWithSelf() is not a function.`);
+    expect(() => new Parcel(data).delete()).toThrowError(`.delete() cannot be called with 0 arguments.`);
+    expect(() => new Parcel(data).swapNext()).toThrowError(`.swapNext() cannot be called with 0 arguments.`);
 });
 
 test('Correct methods are created for object values', () => {
@@ -147,8 +147,8 @@ test('Correct methods are created for object values', () => {
     expect(() => new Parcel(data).value).not.toThrow();
     expect(() => new Parcel(data).has('a')).not.toThrow();
     expect(() => new Parcel(data).pop()).toThrowError(`.pop() is not a function.`);
-    expect(() => new Parcel(data).delete()).toThrowError(`.deleteSelf() is not a function.`);
-    expect(() => new Parcel(data).swapNext()).toThrowError(`.swapNextWithSelf() is not a function.`);
+    expect(() => new Parcel(data).delete()).toThrowError(`.delete() cannot be called with 0 arguments.`);
+    expect(() => new Parcel(data).swapNext()).toThrowError(`.swapNext() cannot be called with 0 arguments.`);
 });
 
 test('Correct methods are created for array values', () => {
@@ -158,8 +158,8 @@ test('Correct methods are created for array values', () => {
     expect(() => new Parcel(data).value).not.toThrow();
     expect(() => new Parcel(data).has('a')).not.toThrow();
     expect(() => new Parcel(data).pop()).not.toThrow();
-    expect(() => new Parcel(data).delete()).toThrowError(`.deleteSelf() is not a function.`);
-    expect(() => new Parcel(data).swapNext()).toThrowError(`.swapNextWithSelf() is not a function.`);
+    expect(() => new Parcel(data).delete()).toThrowError(`.delete() cannot be called with 0 arguments.`);
+    expect(() => new Parcel(data).swapNext()).toThrowError(`.swapNext() cannot be called with 0 arguments.`);
 });
 
 test('Correct methods are created for object child values', () => {
@@ -170,7 +170,7 @@ test('Correct methods are created for object child values', () => {
     expect(() => new Parcel(data).get("a").has('a')).toThrowError(`.has() is not a function.`);
     expect(() => new Parcel(data).get("a").pop()).toThrowError(`.pop() is not a function.`);
     expect(() => new Parcel(data).get("a").delete()).not.toThrow();
-    expect(() => new Parcel(data).get("a").swapNext()).toThrowError(`.swapNextWithSelf() is not a function.`);
+    expect(() => new Parcel(data).get("a").swapNext()).toThrowError(`.swapNext() cannot be called with 0 arguments.`);
 });
 
 test('Correct methods are created for array element values', () => {

--- a/packages/dataparcels/src/parcel/__test__/ParcelTypes-test.js
+++ b/packages/dataparcels/src/parcel/__test__/ParcelTypes-test.js
@@ -136,8 +136,8 @@ test('Correct methods are created for primitive values', () => {
     expect(() => new Parcel(data).value).not.toThrow();
     expect(() => new Parcel(data).has('a')).toThrowError(`.has() is not a function.`);
     expect(() => new Parcel(data).pop()).toThrowError(`.pop() is not a function.`);
-    expect(() => new Parcel(data).delete()).toThrowError(`.delete() is not a function.`);
-    expect(() => new Parcel(data).swapNext()).toThrowError(`.swapNext() is not a function.`);
+    expect(() => new Parcel(data).delete()).toThrowError(`.deleteSelf() is not a function.`);
+    expect(() => new Parcel(data).swapNext()).toThrowError(`.swapNextWithSelf() is not a function.`);
 });
 
 test('Correct methods are created for object values', () => {
@@ -147,8 +147,8 @@ test('Correct methods are created for object values', () => {
     expect(() => new Parcel(data).value).not.toThrow();
     expect(() => new Parcel(data).has('a')).not.toThrow();
     expect(() => new Parcel(data).pop()).toThrowError(`.pop() is not a function.`);
-    expect(() => new Parcel(data).delete()).toThrowError(`.delete() is not a function.`);
-    expect(() => new Parcel(data).swapNext()).toThrowError(`.swapNext() is not a function.`);
+    expect(() => new Parcel(data).delete()).toThrowError(`.deleteSelf() is not a function.`);
+    expect(() => new Parcel(data).swapNext()).toThrowError(`.swapNextWithSelf() is not a function.`);
 });
 
 test('Correct methods are created for array values', () => {
@@ -158,8 +158,8 @@ test('Correct methods are created for array values', () => {
     expect(() => new Parcel(data).value).not.toThrow();
     expect(() => new Parcel(data).has('a')).not.toThrow();
     expect(() => new Parcel(data).pop()).not.toThrow();
-    expect(() => new Parcel(data).delete()).toThrowError(`.delete() is not a function.`);
-    expect(() => new Parcel(data).swapNext()).toThrowError(`.swapNext() is not a function.`);
+    expect(() => new Parcel(data).delete()).toThrowError(`.deleteSelf() is not a function.`);
+    expect(() => new Parcel(data).swapNext()).toThrowError(`.swapNextWithSelf() is not a function.`);
 });
 
 test('Correct methods are created for object child values', () => {
@@ -170,7 +170,7 @@ test('Correct methods are created for object child values', () => {
     expect(() => new Parcel(data).get("a").has('a')).toThrowError(`.has() is not a function.`);
     expect(() => new Parcel(data).get("a").pop()).toThrowError(`.pop() is not a function.`);
     expect(() => new Parcel(data).get("a").delete()).not.toThrow();
-    expect(() => new Parcel(data).get("a").swapNext()).toThrowError(`.swapNext() is not a function.`);
+    expect(() => new Parcel(data).get("a").swapNext()).toThrowError(`.swapNextWithSelf() is not a function.`);
 });
 
 test('Correct methods are created for array element values', () => {

--- a/packages/dataparcels/src/parcel/__test__/ParentChangeMethods-test.js
+++ b/packages/dataparcels/src/parcel/__test__/ParentChangeMethods-test.js
@@ -75,3 +75,19 @@ test('ParentParcel.updateIn(keyPath) should call the Parcels handleChange functi
         return "???";
     });
 });
+
+test('ParentParcel.deleteIn(keyPath) should delete deeply', () => {
+    var data = {
+        value: {
+            a: {
+                b: "!!!"
+            }
+        },
+        handleChange: (parcel) => {
+            let {value} = parcel.data;
+            expect(value).toEqual({a: {}});
+        }
+    };
+
+    new Parcel(data).deleteIn(["a", "b"]);
+});

--- a/packages/dataparcels/src/parcel/__test__/ParentGetMethods-test.js
+++ b/packages/dataparcels/src/parcel/__test__/ParentGetMethods-test.js
@@ -200,7 +200,7 @@ test('ParentParcel.get() should cache its parcelData.child after its calculated,
         parcel.get(1);
     });
 
-    expect(ms / 100 > ms2).toBe(true); // expect amazing performance boosts from having cached
+    expect(ms / 25).toBeGreaterThan(ms2); // expect amazing performance boosts from having cached
 
     parcel.get(0).onChange(123);
 });

--- a/packages/dataparcels/src/parcel/methods/ElementChangeMethods.js
+++ b/packages/dataparcels/src/parcel/methods/ElementChangeMethods.js
@@ -16,16 +16,16 @@ export default (_this: Parcel, dispatch: Function): Object => ({
         dispatch(ActionCreators.insertBeforeSelf(value));
     },
 
-    swapNextWithSelf: () => {
-        dispatch(ActionCreators.swapNextWithSelf());
+    swapNextSelf: () => {
+        dispatch(ActionCreators.swapNextSelf());
     },
 
-    swapPrevWithSelf: () => {
-        dispatch(ActionCreators.swapPrevWithSelf());
+    swapPrevSelf: () => {
+        dispatch(ActionCreators.swapPrevSelf());
     },
 
-    swapWithSelf: (key: Key|Index) => {
-        Types(`swapWithSelf() expects param "key" to be`, `keyIndex`)(key);
-        dispatch(ActionCreators.swapWithSelf(key));
+    swapSelf: (key: Key|Index) => {
+        Types(`swapSelf() expects param "key" to be`, `keyIndex`)(key);
+        dispatch(ActionCreators.swapSelf(key));
     }
 });

--- a/packages/dataparcels/src/parcel/methods/ModifyMethods.js
+++ b/packages/dataparcels/src/parcel/methods/ModifyMethods.js
@@ -58,7 +58,7 @@ export default (_this: Parcel): Object => ({
             pipeWith(
                 changeRequest.data.value,
                 updater,
-                parcel.dangerouslyReplaceSelf
+                parcel.dangerouslyReplace
             );
         });
     },

--- a/packages/dataparcels/src/parcel/methods/ParcelChangeMethods.js
+++ b/packages/dataparcels/src/parcel/methods/ParcelChangeMethods.js
@@ -18,11 +18,11 @@ export default (_this: Parcel, dispatch: Function) => ({
 
     updateSelf: (updater: ParcelValueUpdater) => {
         Types(`updateSelf() expects param "updater" to be`, `function`)(updater);
-        _this.setSelf(updater(_this.value));
+        _this.set(updater(_this.value));
     },
 
     onChange: (value: *) => {
-        _this.setSelf(value);
+        _this.set(value);
     },
 
     onChangeDOM: (event: Object) => {
@@ -55,7 +55,7 @@ export default (_this: Parcel, dispatch: Function) => ({
         dispatch(ActionCreators.ping());
     },
 
-    dangerouslyReplaceSelf: (value: *) => {
-        dispatch(ActionCreators.dangerouslyReplaceSelf(value));
+    dangerouslyReplace: (value: *) => {
+        dispatch(ActionCreators.dangerouslyReplace(value));
     }
 });

--- a/packages/dataparcels/src/parcel/methods/ParentChangeMethods.js
+++ b/packages/dataparcels/src/parcel/methods/ParentChangeMethods.js
@@ -26,5 +26,10 @@ export default (_this: Parcel /*, dispatch: Function*/): Object => ({
         Types(`updateIn() expects param "keyPath" to be`, `keyIndexPath`)(keyPath);
         Types(`update() expects param "updater" to be`, `function`)(updater);
         _this.getIn(keyPath).update(updater);
+    },
+
+    deleteIn: (keyPath: Array<Key|Index>) => {
+        Types(`deleteIn() expects param "keyPath" to be`, `keyIndexPath`)(keyPath);
+        _this.getIn(keyPath).delete();
     }
 });

--- a/packages/dataparcels/src/parcel/methods/ParentChangeMethods.js
+++ b/packages/dataparcels/src/parcel/methods/ParentChangeMethods.js
@@ -8,23 +8,23 @@ import Types from '../../types/Types';
 export default (_this: Parcel /*, dispatch: Function*/): Object => ({
     set: (key: Key|Index, value: *) => {
         Types(`set() expects param "key" to be`, `keyIndex`)(key);
-        _this.get(key).setSelf(value);
+        _this.get(key).set(value);
     },
 
     update: (key: Key|Index, updater: ParcelValueUpdater) => {
         Types(`update() expects param "key" to be`, `keyIndex`)(key);
         Types(`update() expects param "updater" to be`, `function`)(updater);
-        _this.get(key).updateSelf(updater);
+        _this.get(key).update(updater);
     },
 
     setIn: (keyPath: Array<Key|Index>, value: *) => {
         Types(`setIn() expects param "keyPath" to be`, `keyIndexPath`)(keyPath);
-        _this.getIn(keyPath).setSelf(value);
+        _this.getIn(keyPath).set(value);
     },
 
     updateIn: (keyPath: Array<Key|Index>, updater: ParcelValueUpdater) => {
         Types(`updateIn() expects param "keyPath" to be`, `keyIndexPath`)(keyPath);
         Types(`update() expects param "updater" to be`, `function`)(updater);
-        _this.getIn(keyPath).updateSelf(updater);
+        _this.getIn(keyPath).update(updater);
     }
 });

--- a/packages/dataparcels/src/parcelData/updateChild.js
+++ b/packages/dataparcels/src/parcelData/updateChild.js
@@ -4,7 +4,6 @@ import type {ParcelData} from '../types/Types';
 import clear from 'unmutable/lib/clear';
 import get from 'unmutable/lib/get';
 import reduce from 'unmutable/lib/reduce';
-import set from 'unmutable/lib/set';
 import shallowToJS from 'unmutable/lib/shallowToJS';
 import isValueObject from 'unmutable/lib/util/isValueObject';
 import pipeWith from 'unmutable/lib/util/pipeWith';

--- a/packages/dataparcels/src/util/FilterMethods.js
+++ b/packages/dataparcels/src/util/FilterMethods.js
@@ -14,8 +14,13 @@ export default (parcelType: string, methodCreator: Function) => (parcel: Parcel,
 
     return pipeWith(
         methods,
-        map((value, key) => () => {
-            throw new Error(`.${key}() is not a function. .${key}() only exists on parcels of type "${parcelType}". The parcel at [${parcel.path.join(', ')}] has a value of "${parcel.value}" and is not of type "${parcelType}".`);
+        map((value, key) => (...args: Array<*>) => {
+            let suffix = `It can only be called on parcels of type "${parcelType}". This parcel has a value of "${parcel.value}" and is not of type "${parcelType}" (keyPath: [${parcel.path.join(', ')}]).`;
+
+            if(key.slice(-4) === "Self") {
+                throw new Error(`.${key.slice(0, -4)}() cannot be called with ${args.length} argument${args.length === 1 ? "" : "s"}. ${suffix}`);
+            }
+            throw new Error(`.${key}() is not a function. It can only be called on parcels of type "${parcelType}". ${suffix}`);
         })
     );
 };

--- a/packages/react-dataparcels/README.md
+++ b/packages/react-dataparcels/README.md
@@ -1,10 +1,9 @@
-# 📦 Dataparcels
+# Dataparcels
 
-A super declarative user input library that works really well with React.
+A library for editing data structures that works really well with React.
 
-*Almost done!*
 
-### [See the very very unfinished docs](https://blueflag.github.io/dataparcels)
+### [See the semi-unfinished docs](https://blueflag.github.io/dataparcels)
 
 ## Installation
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3222,9 +3222,9 @@ dateformat@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
 
-dcme-style@^0.16.1:
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/dcme-style/-/dcme-style-0.16.1.tgz#b219a7f1ca0784bd4cf602e1f0c254281133dae8"
+dcme-style@^0.16.2:
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/dcme-style/-/dcme-style-0.16.2.tgz#9edbbb7cf1a8811dc6706f66068997cffc3947bd"
   dependencies:
     react-goose "^0.4.2"
     react-select "^1.0.0-rc.4"


### PR DESCRIPTION
- Removed "Self" methods and replaced with overloaded versions. This brings it much closer to Immutable.js and makes the size of the API a little more manageable.
  - **BREAKING CHANGE** `setSelf()` is now `set()` with 1 argument
  - **BREAKING CHANGE** `updateSelf()` is now `update()` with 1 argument
  - **BREAKING CHANGE** `deleteSelf()` is now `delete()` with 0 arguments
  - **BREAKING CHANGE** `insertAfterSelf()` is now `insertAfter()` with 1 argument
  - **BREAKING CHANGE** `insertBeforeSelf()` is now `insertBefore()` with 1 argument
  - **BREAKING CHANGE** `swapWithSelf()` is now `swap()` with 1 argument
  - **BREAKING CHANGE** `swapNextWithSelf()` is now `swapNext()` with 0 arguments
  - **BREAKING CHANGE** `swapPrevWithSelf()` is now `swapPrev()` with 0 arguments
  - **BREAKING CHANGE** `dangerouslyReplaceSelf()` is now `dangerouslyReplace()`
  - Added `deleteIn()`
- Add more docs, show function signatures for all Parcel methods