### PR TITLE
Prevent addModifier and addDescendantModifier from mutating

### DIFF
--- a/packages/dataparcels/src/parcel/Parcel.js
+++ b/packages/dataparcels/src/parcel/Parcel.js
@@ -149,15 +149,18 @@ export default class Parcel {
     _create = (createParcelConfig: CreateParcelConfigType): Parcel => {
         let {
             id = this._id,
-            parcelData: {
-                child,
-                value,
-                meta = {}
-            },
-            parent,
             onDispatch = this.dispatch,
-            handleChange
+            handleChange,
+            modifiers = this._modifiers,
+            parent,
+            parcelData = this._parcelData
         } = createParcelConfig;
+
+        let {
+            child,
+            value,
+            meta = {}
+        } = parcelData;
 
         let parcel: Parcel = new Parcel(
             {
@@ -168,7 +171,7 @@ export default class Parcel {
                 child,
                 meta,
                 id,
-                modifiers: this._modifiers,
+                modifiers,
                 onDispatch,
                 parent,
                 treeshare: this._treeshare

--- a/packages/dataparcels/src/parcel/methods/ModifyMethods.js
+++ b/packages/dataparcels/src/parcel/methods/ModifyMethods.js
@@ -32,20 +32,15 @@ export default (_this: Parcel): Object => ({
 
     modifyChange: (batcher: Function): Parcel => {
         Types(`modifyChange() expects param "batcher" to be`, `function`)(batcher);
-        return pipeWith(
-            _this._parcelData,
-            parcelData => ({
-                parcelData,
-                id: _this._id.pushModifier('mc'),
-                onDispatch: (changeRequest: ChangeRequest) => {
-                    _this.batch(
-                        (parcel: Parcel) => batcher(parcel, changeRequest._setBaseParcel(parcel)),
-                        changeRequest
-                    );
-                }
-            }),
-            _this._create
-        );
+        return _this._create({
+            id: _this._id.pushModifier('mc'),
+            onDispatch: (changeRequest: ChangeRequest) => {
+                _this.batch(
+                    (parcel: Parcel) => batcher(parcel, changeRequest._setBaseParcel(parcel)),
+                    changeRequest
+                );
+            }
+        });
     },
 
     modifyChangeValue: (updater: Function): Parcel => {
@@ -85,11 +80,9 @@ export default (_this: Parcel): Object => ({
             );
 
         return pipeWith(
-            _this._parcelData,
-            parcelData => ({
-                parcelData,
+            {
                 id: _this._id.pushModifier('im')
-            }),
+            },
             metaSetter,
             _this._create
         );
@@ -106,21 +99,17 @@ export default (_this: Parcel): Object => ({
 
     addDescendantModifier: (modifier: ModifierFunction|ModifierObject): Parcel => {
         Types(`addDescendantModifier() expects param "modifier" to be`, `modifier`)(modifier);
-        // explicitly mutate, see https://github.com/blueflag/parcels/issues/43
-        _this._modifiers =_this._modifiers.add(modifier);
-        return _this;
+        return _this._create({
+            id: _this._id.pushModifier('am'),
+            modifiers: _this._modifiers.add(modifier)
+        });
     },
 
     _boundarySplit: ({handleChange}: *): Parcel => {
-        return pipeWith(
-            _this._parcelData,
-            parcelData => ({
-                parcelData,
-                id: _this._id.pushModifier('mb'),
-                parent: _this._parent,
-                handleChange
-            }),
-            _this._create
-        );
+        return _this._create({
+            id: _this._id.pushModifier('mb'),
+            parent: _this._parent,
+            handleChange
+        });
     }
 });

--- a/packages/dataparcels/src/types/Types.js
+++ b/packages/dataparcels/src/types/Types.js
@@ -33,8 +33,9 @@ export type ParcelConfigInternal = {
 
 export type CreateParcelConfigType = {
     onDispatch?: Function,
-    id: ParcelId,
-    parcelData: ParcelData,
+    id?: ParcelId,
+    modifiers?: Modifiers,
+    parcelData?: ParcelData,
     parent?: Parcel,
     handleChange?: Function
 };


### PR DESCRIPTION
- **BREAKING CHANGE** `Parcel.addModifier()` and `Parcel.addDescendantModifier()` no longer mutate.
  - The original reasoning behind allowing mutations was described [here](https://github.com/blueflag/parcels/issues/43), however this "fix" was not robust as you could end up calling `addModifier` multiple times on the same parcel unknowningly when using `ParcelHoc.pipe`, when props change without changing the Parcel. This would stacking up extra modifiers on the same parcel each time `ParcelHoc.pipe()` was called. `setInternalLocationShareData` solves the original use case far better.
- Also internally allowed `_create()` to default to the current `parcelData`, which makes for simpler calls to `_create()`