### PR TITLE
Feature/parcelboundaryhoc

### DIFF
--- a/packages/dataparcels-docs/src/content/API.js
+++ b/packages/dataparcels-docs/src/content/API.js
@@ -47,5 +47,5 @@ export default () => <Box>
             image={IconParcelBoundary}
         />
     </Grid>
-    <Text element="p" modifier="margin">See also: <Link className="Link" to="/api/ChangeRequest">ChangeRequest</Link>, <Link className="Link" to="/api/Action">Action</Link>.</Text>
+    <Text element="p" modifier="margin">See also: <Link className="Link" to="/api/ParcelBoundaryHoc">ParcelBoundaryHoc</Link>, <Link className="Link" to="/api/ChangeRequest">ChangeRequest</Link>, <Link className="Link" to="/api/Action">Action</Link>.</Text>
 </Box>;

--- a/packages/dataparcels-docs/src/docs/api/parcelBoundary/ParcelBoundary.md
+++ b/packages/dataparcels-docs/src/docs/api/parcelBoundary/ParcelBoundary.md
@@ -5,6 +5,7 @@ import ParcelHocExample from 'pages/examples/parcelhoc-example.md';
 import ParcelHocInitialValueFromProps from 'pages/examples/parcelhoc-initialvalue.md';
 import ParcelHocOnChange from 'pages/examples/parcelhoc-onchange.md';
 import IconParcelBoundary from 'content/parcelboundary.gif';
+import {Box, Message} from 'dcme-style';
 
 # ParcelBoundary
 
@@ -32,3 +33,7 @@ import {ParcelBoundary} from 'react-dataparcels';
     {(parcel, actions) => Node}
 </ParcelBoundary>
 ```
+
+<Box modifier="margin">
+    <Message>ParcelBoundary is also available as a React higher order component, <Link to="/api/ParcelBoundaryHoc">ParcelBoundaryHoc</Link>.</Message>
+</Box>

--- a/packages/dataparcels-docs/src/docs/api/parcelBoundary/childRenderer.md
+++ b/packages/dataparcels-docs/src/docs/api/parcelBoundary/childRenderer.md
@@ -13,7 +13,8 @@ ParcelBoundaryActions = {
 
 ParcelBoundaries must be given a `childRenderer` function as children. This is called whenever the ParcelBoundary updates.
 
-It is passed a `parcel`, and a set of `actions` that can be used to control the ParcelBoundary's action buffer (see the <Link to="/examples/parcelboundary-hold">hold example</Link>).
+It is passed a `parcel` and a set of `actions`. The parcel is on the "inside" of the parcel boundary, and is able to update independently of the parcel that was passed into the ParcelBoundary.
+The actions can be used to control the ParcelBoundary's action buffer (see the <Link to="/examples/parcelboundary-hold">hold example</Link>). 
 
 The return value of `childRenderer` will be rendered.
 

--- a/packages/dataparcels-docs/src/docs/api/parcelBoundaryHoc/ParcelBoundaryHoc.md
+++ b/packages/dataparcels-docs/src/docs/api/parcelBoundaryHoc/ParcelBoundaryHoc.md
@@ -1,0 +1,36 @@
+import Link from 'component/Link';
+import Param from 'component/Param';
+import ParcelHocExample from 'pages/examples/parcelhoc-example.md';
+import ParcelHocInitialValueFromProps from 'pages/examples/parcelhoc-initialvalue.md';
+import ParcelHocOnChange from 'pages/examples/parcelhoc-onchange.md';
+import IconParcelBoundary from 'content/parcelboundary.gif';
+import {Box, Message} from 'dcme-style';
+
+# ParcelBoundaryHoc
+
+ParcelBoundaryHoc is a React higher order component. It's job is to control the flow of parcel changes. It is the higher oder component version of a <Link to="/api/ParcelBoundary">ParcelBoundary</Link>.
+
+Each ParcelBoundaryHoc is given a name, and expects that it will be given Parcel as a prop of the same name.
+
+ParcelBoundaryHocs have an internal action buffer that can hold onto changes as they exit the boundary. These are normally released immediately, but also allow for debouncing changes, or putting a hold on all changes so they can be released later or cancelled.
+
+Unlike <Link to="/api/ParcelBoundary">ParcelBoundary</Link>, it cannot use pure rendering.
+
+```js
+import {ParcelBoundaryHoc} from 'react-dataparcels';
+```
+
+```js
+ParcelBoundaryHoc({
+    name: string | (props: *) => string,
+    debounce?: number | (props: *) => number,
+    hold?: boolean | (props: *) => boolean,
+    originalParcelProp?: string | (props: *) => string,
+    // debugging options
+    debugBuffer?: boolean
+});
+```
+
+<Box modifier="margin">
+    <Message>ParcelBoundaryHoc is also available as a React component, <Link to="/api/ParcelBoundary">ParcelBoundary</Link>.</Message>
+</Box>

--- a/packages/dataparcels-docs/src/docs/api/parcelBoundaryHoc/childName.md
+++ b/packages/dataparcels-docs/src/docs/api/parcelBoundaryHoc/childName.md
@@ -1,0 +1,9 @@
+import Link from 'component/Link';
+
+```flow
+${name}: Parcel
+```
+
+ParcelBoundaryHoc's child component will receive a Parcel as a prop, with the name of the prop specified by `config.name`. This parcel is on the "inside" of the parcel boundary, and is able to update independently of the parcel that was passed into the ParcelBoundaryHoc.
+
+If ParcelBoundaryHoc doesn't receive a parcel as a prop at the name indicated by `config.name`, then this child prop will not exist.

--- a/packages/dataparcels-docs/src/docs/api/parcelBoundaryHoc/childNameActions.md
+++ b/packages/dataparcels-docs/src/docs/api/parcelBoundaryHoc/childNameActions.md
@@ -1,0 +1,9 @@
+import Link from 'component/Link';
+
+```flow
+${name}Actions: {release: () => void, cancel: () => void}
+```
+
+ParcelBoundaryHoc's child component will receive a set of actions that can be used to control the ParcelBoundaryHoc's action buffer.
+
+If ParcelBoundaryHoc doesn't receive a parcel as a prop at the name indicated by `config.name`, then this child prop will not exist.

--- a/packages/dataparcels-docs/src/docs/api/parcelBoundaryHoc/childOriginalParcelProp.md
+++ b/packages/dataparcels-docs/src/docs/api/parcelBoundaryHoc/childOriginalParcelProp.md
@@ -1,0 +1,7 @@
+import Link from 'component/Link';
+
+```flow
+${originalParcelProp}: Parcel
+```
+
+If `config.originalParcelProp` exists, ParcelBoundaryHoc's child component will receive the original Parcel that was passed into the ParcelBoundaryHoc.

--- a/packages/dataparcels-docs/src/docs/api/parcelBoundaryHoc/debounce.md
+++ b/packages/dataparcels-docs/src/docs/api/parcelBoundaryHoc/debounce.md
@@ -1,0 +1,17 @@
+import Link from 'component/Link';
+
+```flow
+debounce?: number | (props: *) => number // optional
+```
+
+If set, `debounce` will debounce any changes that occur inside the ParcelBoundaryHoc. The number indicates the number of milliseconds to debounce.
+
+This can be used to increase rendering performance for parcels that change value many times in rapid succession, such as text inputs.
+
+#### Debouncing explained
+
+When the `parcel` in the ParcelBoundaryHoc sends a change, the ParcelBoundaryHoc will catch it and prevent it from being propagated out of the boundary. The parcel on the inside of the ParcelBoundaryHoc will still update as normal.
+
+The ParcelBoundaryHoc waits until no new changes have occured for `debounce` number of milliseconds. It then releases all the changes it has buffered, all together in a single change request.
+
+Debouncing can be good for rendering performance because parcels outside the ParcelBoundaryHoc don't needlessly update every time a small change occurs (e.g. each time the user presses a key).

--- a/packages/dataparcels-docs/src/docs/api/parcelBoundaryHoc/debugBuffer.md
+++ b/packages/dataparcels-docs/src/docs/api/parcelBoundaryHoc/debugBuffer.md
@@ -1,0 +1,5 @@
+```flow
+debugBuffer?: boolean = false // optional
+```
+
+Wehn `debugBuffer` is true, ParcelBoundaryHoc will log out changes relating to its internal action buffer.

--- a/packages/dataparcels-docs/src/docs/api/parcelBoundaryHoc/hold.md
+++ b/packages/dataparcels-docs/src/docs/api/parcelBoundaryHoc/hold.md
@@ -1,0 +1,7 @@
+import Link from 'component/Link';
+
+```flow
+hold?: boolean | (props: *) => boolean // optional
+```
+
+When `hold` is true, all changes made to the parcel inside the ParcelBoundaryHoc are prevented from being propagated out of the boundary. The parcel beneath will continue to update as normal. You can then call the `release()` action to release all the buffered changes at once, or the `cancel()` action to cancel all the buffered changes. This can be useful for building UIs that have a submit action.

--- a/packages/dataparcels-docs/src/docs/api/parcelBoundaryHoc/name.md
+++ b/packages/dataparcels-docs/src/docs/api/parcelBoundaryHoc/name.md
@@ -1,0 +1,9 @@
+import Link from 'component/Link';
+
+```flow
+name: string | (props: *) => string
+```
+
+The name of the prop that will contain a parcel.
+
+The parcel is allowed to be undefined, in which case the ParcelBoundaryHoc will have no effect. 

--- a/packages/dataparcels-docs/src/docs/api/parcelBoundaryHoc/originalParcelProp.md
+++ b/packages/dataparcels-docs/src/docs/api/parcelBoundaryHoc/originalParcelProp.md
@@ -1,0 +1,7 @@
+import Link from 'component/Link';
+
+```flow
+originalParcelProp?: string | (props: *) => string // optional
+```
+
+If set, ParcelBoundaryHoc will pass down the original parcel as a prop to its children. The name of the prop is specified by `originalParcelProp`.

--- a/packages/dataparcels-docs/src/docs/api/parcelHoc/childName.md
+++ b/packages/dataparcels-docs/src/docs/api/parcelHoc/childName.md
@@ -1,0 +1,7 @@
+import Link from 'component/Link';
+
+```flow
+${name}: Parcel
+```
+
+ParceHoc's child component will receive a Parcel as a prop, with the name of the prop specified by `config.name`.

--- a/packages/dataparcels-docs/src/pages/api/ParcelBoundaryHoc.jsx
+++ b/packages/dataparcels-docs/src/pages/api/ParcelBoundaryHoc.jsx
@@ -1,0 +1,45 @@
+// @flow
+import type {Node} from 'react';
+import React from 'react';
+import ApiPage from 'component/ApiPage';
+import Markdown_ParcelBoundaryHoc from 'docs/api/parcelBoundaryHoc/ParcelBoundaryHoc.md';
+import Markdown_name from 'docs/api/parcelBoundaryHoc/name.md';
+import Markdown_originalParcelProp from 'docs/api/parcelBoundaryHoc/originalParcelProp.md';
+import Markdown_debounce from 'docs/api/parcelBoundaryHoc/debounce.md';
+import Markdown_hold from 'docs/api/parcelBoundaryHoc/hold.md';
+import Markdown_debugBuffer from 'docs/api/parcelBoundaryHoc/debugBuffer.md';
+import Markdown_childName from 'docs/api/parcelBoundaryHoc/childName.md';
+import Markdown_childNameActions from 'docs/api/parcelBoundaryHoc/childNameActions.md';
+import Markdown_childOriginalParcelProp from 'docs/api/parcelBoundaryHoc/childOriginalParcelProp.md';
+
+const md = {
+    _desc: Markdown_ParcelBoundaryHoc,
+    name: Markdown_name,
+    originalParcelProp: Markdown_originalParcelProp,
+    debounce: Markdown_debounce,
+    hold: Markdown_hold,
+    debugBuffer: Markdown_debugBuffer,
+    ['${name}']: Markdown_childName,
+    ['${name}Actions']: Markdown_childNameActions,
+    ['${originalParcelProp}']: Markdown_childOriginalParcelProp
+}
+
+const api = `
+# Config
+name
+originalParcelProp
+debounce
+hold
+debugBuffer
+
+# Child props
+$\{name\}
+$\{name\}Actions
+$\{originalParcelProp\}
+`;
+
+export default () => <ApiPage
+    name="ParcelBoundaryHoc"
+    api={api}
+    md={md}
+/>;

--- a/packages/dataparcels-docs/src/pages/api/ParcelHoc.jsx
+++ b/packages/dataparcels-docs/src/pages/api/ParcelHoc.jsx
@@ -10,6 +10,7 @@ import Markdown_delayUntil from 'docs/api/parcelHoc/delayUntil.md';
 import Markdown_onChange from 'docs/api/parcelHoc/onChange.md';
 import Markdown_pipe from 'docs/api/parcelHoc/pipe.md';
 import Markdown_debugRender from 'docs/api/parcelHoc/debugRender.md';
+import Markdown_childName from 'docs/api/parcelHoc/childName.md';
 
 const md = {
     _desc: Markdown_ParcelHoc,
@@ -19,7 +20,8 @@ const md = {
     delayUntil: Markdown_delayUntil,
     onChange: Markdown_onChange,
     pipe: Markdown_pipe,
-    debugRender: Markdown_debugRender
+    debugRender: Markdown_debugRender,
+    ['${name}']: Markdown_childName
 }
 
 const api = `
@@ -30,6 +32,9 @@ delayUntil
 onChange
 pipe
 debugRender
+
+# Child props
+$\{name\}
 `;
 
 export default () => <ApiPage

--- a/packages/dataparcels/src/parcel/Parcel.js
+++ b/packages/dataparcels/src/parcel/Parcel.js
@@ -49,7 +49,7 @@ const DEFAULT_CONFIG_INTERNAL = () => ({
 
 export default class Parcel {
     constructor(config: ParcelConfig = {}, _configInternal: ?ParcelConfigInternal) {
-        Types(`Parcel() expects param "config" to be`, `object`)(config);
+        Types(`Parcel()`, `config`, `object`)(config);
 
         let {
             handleChange,
@@ -57,8 +57,8 @@ export default class Parcel {
             debugRender = false
         } = config;
 
-        handleChange && Types(`Parcel() expects param "config.handleChange" to be`, `function`)(handleChange);
-        Types(`Parcel() expects param "config.debugRender" to be`, `boolean`)(debugRender);
+        handleChange && Types(`Parcel()`, `config.handleChange`, `function`)(handleChange);
+        Types(`Parcel()`, `config.debugRender`, `boolean`)(debugRender);
 
         let {
             onDispatch,

--- a/packages/dataparcels/src/parcel/methods/ActionMethods.js
+++ b/packages/dataparcels/src/parcel/methods/ActionMethods.js
@@ -10,7 +10,7 @@ import ChangeRequest from '../../change/ChangeRequest';
 export default (_this: Parcel): Object => ({
 
     dispatch: (dispatchable: Action|Action[]|ChangeRequest) => {
-        Types(`dispatch() expects param "dispatchable" to be`, `dispatchable`)(dispatchable);
+        Types(`dispatch()`, `dispatchable`, `dispatchable`)(dispatchable);
 
 
         let {
@@ -55,7 +55,7 @@ export default (_this: Parcel): Object => ({
     },
 
     batch: (batcher: ParcelBatcher, changeRequest: ?ChangeRequest) => {
-        Types(`batch() expects param "batcher" to be`, `function`)(batcher);
+        Types(`batch()`, `batcher`, `function`)(batcher);
 
         let parcelData: ParcelData = _this._parcelData;
         let lastBuffer = _this._dispatchBuffer;

--- a/packages/dataparcels/src/parcel/methods/AdvancedMethods.js
+++ b/packages/dataparcels/src/parcel/methods/AdvancedMethods.js
@@ -9,7 +9,7 @@ export default (_this: Parcel): Object => ({
     },
 
     setInternalLocationShareData: (partialData: Object) => {
-        Types(`setInternalLocationShareData() expects param "partialData" to be`, `object`)(partialData);
+        Types(`setInternalLocationShareData()`, `partialData`, `object`)(partialData);
         _this._treeshare.locationShare.set(_this.path, partialData);
     }
 });

--- a/packages/dataparcels/src/parcel/methods/ElementChangeMethods.js
+++ b/packages/dataparcels/src/parcel/methods/ElementChangeMethods.js
@@ -25,7 +25,7 @@ export default (_this: Parcel, dispatch: Function): Object => ({
     },
 
     swapSelf: (key: Key|Index) => {
-        Types(`swapSelf() expects param "key" to be`, `keyIndex`)(key);
+        Types(`swapSelf()`, `key`, `keyIndex`)(key);
         dispatch(ActionCreators.swapSelf(key));
     }
 });

--- a/packages/dataparcels/src/parcel/methods/IndexedChangeMethods.js
+++ b/packages/dataparcels/src/parcel/methods/IndexedChangeMethods.js
@@ -9,17 +9,17 @@ import ActionCreators from '../../change/ActionCreators';
 export default (_this: Parcel, dispatch: Function): Object => ({
 
     delete: (key: Key|Index) => {
-        Types(`delete() expects param "key" to be`, `keyIndex`)(key);
+        Types(`delete()`, `key`, `keyIndex`)(key);
         dispatch(ActionCreators.delete(key));
     },
 
     insertAfter: (key: Key|Index, value: *) => {
-        Types(`insertAfter() expects param "key" to be`, `keyIndex`)(key);
+        Types(`insertAfter()`, `key`, `keyIndex`)(key);
         dispatch(ActionCreators.insertAfter(key, value));
     },
 
     insertBefore: (key: Key|Index, value: *) => {
-        Types(`insertBefore() expects param "key" to be`, `keyIndex`)(key);
+        Types(`insertBefore()`, `key`, `keyIndex`)(key);
         dispatch(ActionCreators.insertBefore(key, value));
     },
 
@@ -36,18 +36,18 @@ export default (_this: Parcel, dispatch: Function): Object => ({
     },
 
     swap: (keyA: Key|Index, keyB: Key|Index) => {
-        Types(`swap() expects param "keyA" to be`, `keyIndex`)(keyA);
-        Types(`swap() expects param "keyB" to be`, `keyIndex`)(keyB);
+        Types(`swap()`, `keyA`, `keyIndex`)(keyA);
+        Types(`swap()`, `keyB`, `keyIndex`)(keyB);
         dispatch(ActionCreators.swap(keyA, keyB));
     },
 
     swapNext: (key: Key|Index) => {
-        Types(`swapNext() expects param "key" to be`, `keyIndex`)(key);
+        Types(`swapNext()`, `key`, `keyIndex`)(key);
         dispatch(ActionCreators.swapNext(key));
     },
 
     swapPrev: (key: Key|Index) => {
-        Types(`swapPrev() expects param "key" to be`, `keyIndex`)(key);
+        Types(`swapPrev()`, `key`, `keyIndex`)(key);
         dispatch(ActionCreators.swapPrev(key));
     },
 

--- a/packages/dataparcels/src/parcel/methods/ModifyMethods.js
+++ b/packages/dataparcels/src/parcel/methods/ModifyMethods.js
@@ -88,7 +88,7 @@ export default (_this: Parcel): Object => ({
 
     _boundarySplit: ({handleChange}: *): Parcel => {
         return _this._create({
-            id: _this._id.pushModifier('mb'),
+            id: _this._id.pushModifier('bs'),
             parent: _this._parent,
             handleChange,
             treeshare: _this._treeshare.boundarySplit()

--- a/packages/dataparcels/src/parcel/methods/ModifyMethods.js
+++ b/packages/dataparcels/src/parcel/methods/ModifyMethods.js
@@ -16,7 +16,7 @@ import pipeWith from 'unmutable/lib/util/pipeWith';
 export default (_this: Parcel): Object => ({
 
     modifyValue: (updater: Function): Parcel => {
-        Types(`modifyValue() expects param "updater" to be`, `function`)(updater);
+        Types(`modifyValue()`, `updater`, `function`)(updater);
         return pipeWith(
             _this._parcelData,
             set('value', updater(_this._parcelData.value, _this)),
@@ -29,7 +29,7 @@ export default (_this: Parcel): Object => ({
     },
 
     modifyChange: (batcher: Function): Parcel => {
-        Types(`modifyChange() expects param "batcher" to be`, `function`)(batcher);
+        Types(`modifyChange()`, `batcher`, `function`)(batcher);
         return _this._create({
             id: _this._id.pushModifier('mc'),
             onDispatch: (changeRequest: ChangeRequest) => {
@@ -42,7 +42,7 @@ export default (_this: Parcel): Object => ({
     },
 
     modifyChangeValue: (updater: Function): Parcel => {
-        Types(`modifyChangeValue() expects param "updater" to be`, `function`)(updater);
+        Types(`modifyChangeValue()`, `updater`, `function`)(updater);
         return _this.modifyChange((parcel: Parcel, changeRequest: ChangeRequest) => {
 
             let valueActionFilter = actions => actions.filter(action => !action.isValueAction());
@@ -57,7 +57,7 @@ export default (_this: Parcel): Object => ({
     },
 
     initialMeta: (initialMeta: ParcelMeta = {}): Parcel => {
-        Types(`initialMeta() expects param "initialMeta" to be`, `object`)(initialMeta);
+        Types(`initialMeta()`, `initialMeta`, `object`)(initialMeta);
         let {meta} = _this._parcelData;
 
         let partialMetaToSet = pipeWith(

--- a/packages/dataparcels/src/parcel/methods/ParcelChangeMethods.js
+++ b/packages/dataparcels/src/parcel/methods/ParcelChangeMethods.js
@@ -17,7 +17,7 @@ export default (_this: Parcel, dispatch: Function) => ({
     },
 
     updateSelf: (updater: ParcelValueUpdater) => {
-        Types(`updateSelf() expects param "updater" to be`, `function`)(updater);
+        Types(`updateSelf()`, `updater`, `function`)(updater);
         _this.set(updater(_this.value));
     },
 
@@ -26,28 +26,28 @@ export default (_this: Parcel, dispatch: Function) => ({
     },
 
     onChangeDOM: (event: Object) => {
-        Types(`onChangeDOM() expects param "event" to be`, `event`)(event);
+        Types(`onChangeDOM()`, `event`, `event`)(event);
         _this.onChange(event.currentTarget.value);
     },
 
     setMeta: (partialMeta: ParcelMeta) => {
-        Types(`setMeta() expects param "partialMeta" to be`, `object`)(partialMeta);
+        Types(`setMeta()`, `partialMeta`, `object`)(partialMeta);
         dispatch(ActionCreators.setMeta(partialMeta));
     },
 
     updateMeta: (updater: ParcelMetaUpdater) => {
-        Types(`updateMeta() expects param "updater" to be`, `function`)(updater);
+        Types(`updateMeta()`, `updater`, `function`)(updater);
         let {meta} = _this._parcelData;
         pipeWith(
             meta,
             updater,
-            Types(`updateMeta() expects the result of updater() to be`, `object`),
+            Types(`updateMeta()`, `the result of updater()`, `object`),
             _this.setMeta
         );
     },
 
     setChangeRequestMeta: (partialMeta: ParcelMeta) => {
-        Types(`setChangeRequestMeta() expects param "partialMeta" to be`, `object`)(partialMeta);
+        Types(`setChangeRequestMeta()`, `partialMeta`, `object`)(partialMeta);
         dispatch(new ChangeRequest().setChangeRequestMeta(partialMeta));
     },
 

--- a/packages/dataparcels/src/parcel/methods/ParcelGetMethods.js
+++ b/packages/dataparcels/src/parcel/methods/ParcelGetMethods.js
@@ -28,22 +28,22 @@ export default (_this: Parcel) => ({
     // Composition methods
 
     pipe: (...updaters: ParcelUpdater[]): Parcel => {
-        Types(`pipe() expects all params to be`, `functionArray`)(updaters);
+        updaters.forEach(Types(`pipe()`, `all updaters`, `function`));
         return pipeWith(
             _this,
             ...pipeWith(
                 updaters,
                 map(updater => pipe(
                     updater,
-                    Types(`pipe() expects the result of all functions to be`, `parcel`)
+                    Types(`pipe()`, `the result of all functions`, `parcel`)
                 ))
             )
         );
     },
 
     matchPipe: (match: string, ...updaters: ParcelUpdater[]): Parcel => {
-        Types(`matchPipe() expects first param to be`, `string`)(match);
-        Types(`matchPipe() expects all but the first param to be`, `functionArray`)(updaters);
+        Types(`matchPipe()`, `first param`, `string`)(match);
+        updaters.forEach(Types(`matchPipe()`, `all updaters`, `function`));
 
         let parcel = _this._create({
             id: _this._id.pushModifier('mp'),
@@ -57,7 +57,7 @@ export default (_this: Parcel) => ({
                             updaters,
                             map(updater => pipe(
                                 updater,
-                                Types(`matchPipe() expects the result of all functions to be`, `parcel`)
+                                Types(`matchPipe() `, `the result of all functions`, `parcel`)
                             ))
                         )
                     )
@@ -97,13 +97,13 @@ export default (_this: Parcel) => ({
     },
 
     spy: (sideEffect: Function): Parcel => {
-        Types(`spy() expects param "sideEffect" to be`, `function`)(sideEffect);
+        Types(`spy()`, `sideEffect`, `function`)(sideEffect);
         sideEffect(_this);
         return _this;
     },
 
     spyChange: (sideEffect: Function): Parcel => {
-        Types(`spyChange() expects param "sideEffect" to be`, `function`)(sideEffect);
+        Types(`spyChange()`, `sideEffect`, `function`)(sideEffect);
         return _this._create({
             id: _this._id.pushModifier('sc'),
             onDispatch: (changeRequest: ChangeRequest) => {

--- a/packages/dataparcels/src/parcel/methods/ParentChangeMethods.js
+++ b/packages/dataparcels/src/parcel/methods/ParentChangeMethods.js
@@ -7,29 +7,29 @@ import Types from '../../types/Types';
 
 export default (_this: Parcel /*, dispatch: Function*/): Object => ({
     set: (key: Key|Index, value: *) => {
-        Types(`set() expects param "key" to be`, `keyIndex`)(key);
+        Types(`set()`, `key`, `keyIndex`)(key);
         _this.get(key).set(value);
     },
 
     update: (key: Key|Index, updater: ParcelValueUpdater) => {
-        Types(`update() expects param "key" to be`, `keyIndex`)(key);
-        Types(`update() expects param "updater" to be`, `function`)(updater);
+        Types(`update()`, `key`, `keyIndex`)(key);
+        Types(`update()`, `updater`, `function`)(updater);
         _this.get(key).update(updater);
     },
 
     setIn: (keyPath: Array<Key|Index>, value: *) => {
-        Types(`setIn() expects param "keyPath" to be`, `keyIndexPath`)(keyPath);
+        Types(`setIn()`, `keyPath`, `keyIndexPath`)(keyPath);
         _this.getIn(keyPath).set(value);
     },
 
     updateIn: (keyPath: Array<Key|Index>, updater: ParcelValueUpdater) => {
-        Types(`updateIn() expects param "keyPath" to be`, `keyIndexPath`)(keyPath);
-        Types(`update() expects param "updater" to be`, `function`)(updater);
+        Types(`updateIn()`, `keyPath`, `keyIndexPath`)(keyPath);
+        Types(`update()`, `updater`, `function`)(updater);
         _this.getIn(keyPath).update(updater);
     },
 
     deleteIn: (keyPath: Array<Key|Index>) => {
-        Types(`deleteIn() expects param "keyPath" to be`, `keyIndexPath`)(keyPath);
+        Types(`deleteIn()`, `keyPath`, `keyIndexPath`)(keyPath);
         _this.getIn(keyPath).delete();
     }
 });

--- a/packages/dataparcels/src/parcel/methods/ParentGetMethods.js
+++ b/packages/dataparcels/src/parcel/methods/ParentGetMethods.js
@@ -27,14 +27,14 @@ export default (_this: Parcel) => ({
     },
 
     has: (key: Key|Index): boolean => {
-        Types(`has() expects param "key" to be`, `keyIndex`)(key);
+        Types(`has()`, `key`, `keyIndex`)(key);
 
         _this._methods._prepareChildKeys();
         return parcelHas(key)(_this._parcelData);
     },
 
     get: (key: Key|Index, notFoundValue: any): Parcel => {
-        Types(`get() expects param "key" to be`, `keyIndex`)(key);
+        Types(`get()`, `key`, `keyIndex`)(key);
 
         _this._methods._prepareChildKeys();
         let childParcelData = parcelGet(key, notFoundValue)(_this._parcelData);
@@ -52,7 +52,7 @@ export default (_this: Parcel) => ({
     },
 
     getIn: (keyPath: Array<Key|Index>, notFoundValue: any): Parcel => {
-        Types(`getIn() expects param "keyPath" to be`, `keyIndexPath`)(keyPath);
+        Types(`getIn()`, `keyPath`, `keyIndexPath`)(keyPath);
         var parcel = _this;
         for(let i = 0; i < keyPath.length; i++) {
             parcel = parcel.get(keyPath[i], i < keyPath.length - 1 ? {} : notFoundValue);
@@ -61,7 +61,7 @@ export default (_this: Parcel) => ({
     },
 
     toObject: (mapper: ParcelMapper): { [key: string]: * } => {
-        Types(`toObject() expects param "mapper" to be`, `function`)(mapper);
+        Types(`toObject()`, `mapper`, `function`)(mapper);
 
         return pipeWith(
             _this._parcelData.value,
@@ -73,7 +73,7 @@ export default (_this: Parcel) => ({
     },
 
     toArray: (mapper: ParcelMapper): Array<*> => {
-        Types(`toArray() expects param "mapper" to be`, `function`)(mapper);
+        Types(`toArray()`, `mapper`, `function`)(mapper);
         return toArray()(_this.toObject(mapper));
     },
 

--- a/packages/dataparcels/src/types/__test__/Types-test.js
+++ b/packages/dataparcels/src/types/__test__/Types-test.js
@@ -20,7 +20,6 @@ let types = {
     ['changeRequest']: new ChangeRequest(),
     ['event']: {currentTarget: {value: null}},
     ['function']: () => {},
-    ['functionArray']: [() => {}, () => {}],
     ['number']: 123,
     ['numberArray']: [123, 456],
     ['object']: {},
@@ -32,14 +31,13 @@ let types = {
 };
 
 let testTypes = (type: string, shouldAllow: string[]) => {
-    let message = `Expected thing to be`;
     pipeWith(
         types,
         map((data, dataType) => {
             if(shouldAllow.indexOf(dataType) !== -1) {
-                expect(() => Types(message, type)(data)).not.toThrowError(`${type} should not throw when given ${dataType}`);
+                expect(() => Types(`Thing`, `Thing`, type)(data)).not.toThrowError(`${type} should not throw when given ${dataType}`);
             } else {
-                expect(() => Types(message, type)(data)).toThrowError(`but got`);
+                expect(() => Types(`Thing`, `Thing`, type)(data)).toThrowError(`but got`);
             }
         })
     );
@@ -68,10 +66,6 @@ test('Types() can identify a function', () => testTypes(`function`, [
     'function'
 ]));
 
-test('Types() can identify a function array', () => testTypes(`functionArray`, [
-    'functionArray'
-]));
-
 test('Types() can identify a keyIndex', () => testTypes(`keyIndex`, [
     'number',
     'string'
@@ -92,7 +86,6 @@ test('Types() can identify a object', () => testTypes(`object`, [
     'botchedActionArray',
     'changeRequest',
     'event',
-    'functionArray',
     'numberArray',
     'object',
     'parcel',

--- a/packages/react-dataparcels/src/ParcelBoundaryHoc.jsx
+++ b/packages/react-dataparcels/src/ParcelBoundaryHoc.jsx
@@ -1,0 +1,85 @@
+// @flow
+import type {ComponentType} from 'react';
+import type {Node} from 'react';
+
+import React from 'react';
+import ParcelBoundary from './ParcelBoundary';
+import Types from 'dataparcels/lib/types/Types';
+
+type Props = {
+    // [config.name]?: Parcel
+};
+type ChildProps = {
+    // [config.name]?: Parcel,
+    // [config.name + "Actions"]?: Parcel,
+    // [config.originalParcelProp]?: Parcel
+    // ...
+};
+
+type ParcelBoundaryHocConfig = {
+    name: string|((props: *) => string),
+    debounce?: number|(props: *) => number,
+    hold?: boolean|(props: *) => boolean,
+    originalParcelProp?: string|(props: *) => string,
+    debugBuffer?: boolean
+};
+
+const PARCEL_BOUNDARY_HOC_NAME = `ParcelBoundaryHoc()`;
+
+export default (config: ParcelBoundaryHocConfig): Function => {
+    Types(`ParcelBoundaryHoc()`, `config`, `object`)(config);
+
+    return (Component: ComponentType<ChildProps>) => class ParcelBoundaryHoc extends React.Component<Props> { /* eslint-disable-line */
+        render(): Node {
+
+            let fromProps = (value) => (typeof value === "function") ? value(this.props) : value;
+
+            // $FlowFixMe - flow can'tm seem to understand that name will never be a boolean or number according to its own previous types
+            let name: string = fromProps(config.name);
+            // $FlowFixMe
+            let debounce: ?number = fromProps(config.debounce) || undefined;
+            // $FlowFixMe
+            let hold: boolean = fromProps(config.hold) || false;
+            // $FlowFixMe
+            let originalParcelProp: ?string = fromProps(config.originalParcelProp);
+            let debugBuffer: boolean = config.debugBuffer || false;
+
+            Types(PARCEL_BOUNDARY_HOC_NAME, "config.name", "string")(name);
+            debounce && Types(PARCEL_BOUNDARY_HOC_NAME, "config.debounce", "number")(debounce);
+            Types(PARCEL_BOUNDARY_HOC_NAME, "config.hold", "boolean")(hold);
+            Types(PARCEL_BOUNDARY_HOC_NAME, "config.debugBuffer", "boolean")(debugBuffer);
+            originalParcelProp && Types(PARCEL_BOUNDARY_HOC_NAME, "config.originalParcelProp", "string")(originalParcelProp);
+
+            let parcel = this.props[name];
+            if(!parcel) {
+                return <Component {...this.props} />;
+            }
+
+            Types(`ParcelBoundaryHoc()`, `prop "${name}"`, `parcel`)(parcel);
+
+            return <ParcelBoundary
+                parcel={parcel}
+                debounce={debounce}
+                hold={hold}
+                debugBuffer={debugBuffer}
+                pure={false}
+            >
+                {(innerParcel, actions) => {
+                    let childProps = {
+                        ...this.props,
+                        // $FlowFixMe - I want to use a computed property, flow
+                        [name]: innerParcel,
+                        // $FlowFixMe - I want to use a computed property, flow
+                        [name + "Actions"]: actions
+                    };
+
+                    if(originalParcelProp) {
+                        childProps[originalParcelProp] = parcel;
+                    }
+
+                    return <Component {...childProps} />;
+                }}
+            </ParcelBoundary>;
+        }
+    };
+};

--- a/packages/react-dataparcels/src/ParcelHoc.jsx
+++ b/packages/react-dataparcels/src/ParcelHoc.jsx
@@ -24,10 +24,10 @@ type ParcelHocConfig = {
     pipe?: (props: Object) => (parcel: Parcel) => Parcel
 };
 
-let ConfigParam = (value, name, verb = "be", type = "function") => Types(`ParcelHoc() expects param "config.${name}" to ${verb}`, type)(value);
+const PARCEL_HOC_NAME = `ParcelHoc()`;
 
 export default (config: ParcelHocConfig): Function => {
-    Types(`ParcelHoc() expects param "config" to be`, `object`)(config);
+    Types(`ParcelHoc()`, `config`, `object`)(config);
 
     let {
         name,
@@ -38,12 +38,12 @@ export default (config: ParcelHocConfig): Function => {
         debugRender = false
     } = config;
 
-    ConfigParam(name, "name", "be", "string");
-    ConfigParam(initialValue, "initialValue");
-    ConfigParam(delayUntil, "delayUntil");
-    ConfigParam(onChange, "onChange");
-    ConfigParam(pipe, "pipe");
-    ConfigParam(debugRender, "debugRender", "be", "boolean");
+    Types(PARCEL_HOC_NAME, "config.name", "string")(name);
+    Types(PARCEL_HOC_NAME, "config.initialValue", "function")(initialValue);
+    Types(PARCEL_HOC_NAME, "config.delayUntil", "function")(delayUntil);
+    Types(PARCEL_HOC_NAME, "config.onChange", "function")(onChange);
+    Types(PARCEL_HOC_NAME, "config.pipe", "function")(pipe);
+    Types(PARCEL_HOC_NAME, "config.debugRender", "boolean")(debugRender);
 
     return (Component: ComponentType<ChildProps>) => class ParcelHoc extends React.Component<Props, State> { /* eslint-disable-line */
         constructor(props: Props) {
@@ -75,7 +75,7 @@ export default (config: ParcelHocConfig): Function => {
         handleChange = (parcel, changeRequest) => {
             this.setState({parcel});
             let onChangeWithProps = onChange(this.props);
-            ConfigParam(onChangeWithProps, "onChange", "return");
+            Types(`handleChange()`, "return value of onChange", "function")(onChangeWithProps);
             onChangeWithProps(parcel.value, changeRequest);
         };
 
@@ -84,9 +84,9 @@ export default (config: ParcelHocConfig): Function => {
 
             if(pipe && parcel) {
                 let pipeWithProps = pipe(this.props);
-                ConfigParam(pipeWithProps, "pipe", "return");
+                Types(`pipe()`, `return value of pipe`, `function`)(pipeWithProps);
                 parcel = pipeWithProps(parcel);
-                ConfigParam(parcel, "pipe(props)", "return", "parcel");
+                Types(`pipe()`, "return value of pipe(props)", `parcel`)(parcel);
             }
 
             let props = {

--- a/packages/react-dataparcels/src/__test__/ParcelBoundary-test.js
+++ b/packages/react-dataparcels/src/__test__/ParcelBoundary-test.js
@@ -13,7 +13,9 @@ import Parcel from 'dataparcels';
 jest.useFakeTimers();
 
 test('ParcelBoundary should pass a *value equivalent* parcel to children', () => {
-    let parcel = new Parcel();
+    let parcel = new Parcel({
+        value: 123
+    });
     let childRenderer = jest.fn();
 
     let wrapper = shallow(<ParcelBoundary parcel={parcel}>

--- a/packages/react-dataparcels/src/__test__/ParcelBoundaryHoc-test.js
+++ b/packages/react-dataparcels/src/__test__/ParcelBoundaryHoc-test.js
@@ -36,7 +36,7 @@ test('ParcelBoundaryHoc config should pass props through with no parcel found', 
         ParcelBoundaryHoc({
             name: 'testParcel'
         })
-    ).dive().props();
+    ).props();
 
     expect(propsGivenToInnerComponent.abc).toBe(123);
     expect(propsGivenToInnerComponent.def).toBe(456);

--- a/packages/react-dataparcels/src/__test__/ParcelBoundaryHoc-test.js
+++ b/packages/react-dataparcels/src/__test__/ParcelBoundaryHoc-test.js
@@ -1,0 +1,186 @@
+// @flow
+import React from 'react';
+
+import Parcel from 'dataparcels';
+import {shallow} from 'enzyme';
+import ParcelBoundaryHoc from '../ParcelBoundaryHoc';
+
+let shallowRenderHoc = (props, hock) => {
+    let Component = hock((props) => <div />);
+    return shallow(<Component {...props}/>);
+};
+
+test('ParcelBoundaryHoc config should pass props through', () => {
+    let propsGivenToInnerComponent = shallowRenderHoc(
+        {
+            testParcel: new Parcel(),
+            abc: 123,
+            def: 456
+        },
+        ParcelBoundaryHoc({
+            name: 'testParcel'
+        })
+    ).dive().props();
+
+    expect(propsGivenToInnerComponent.abc).toBe(123);
+    expect(propsGivenToInnerComponent.def).toBe(456);
+});
+
+test('ParcelBoundaryHoc config should pass ParcelBoundary parcel down under same prop name', () => {
+    let propsGivenToInnerComponent = shallowRenderHoc(
+        {
+            testParcel: new Parcel({
+                value: 789
+            })
+        },
+        ParcelBoundaryHoc({
+            name: 'testParcel'
+        })
+    ).dive().props();
+
+    // parcel has correct contents
+    expect(propsGivenToInnerComponent.testParcel.value).toBe(789);
+
+    // parcel is passed through parcel boundary as evidenced by "~bs" in its id
+    expect(propsGivenToInnerComponent.testParcel.id.indexOf("~bs")).not.toBe(-1);
+});
+
+test('ParcelBoundaryHoc config should pass actions as config.name + "Actions', () => {
+    let propsGivenToInnerComponent = shallowRenderHoc(
+        {
+            testParcel: new Parcel({
+                value: 789
+            })
+        },
+        ParcelBoundaryHoc({
+            name: 'testParcel'
+        })
+    ).dive().props();
+
+    // testParcelActions shoudl contain a ParcelBoundaryActions object
+    expect(typeof propsGivenToInnerComponent.testParcelActions.release).toBe("function");
+    expect(typeof propsGivenToInnerComponent.testParcelActions.cancel).toBe("function");
+});
+
+test('ParcelBoundaryHoc config.name should accept props function returning string', () => {
+    let propsGivenToInnerComponent = shallowRenderHoc(
+        {
+            testParcel: new Parcel({
+                value: 789
+            }),
+            parcelName: 'testParcel'
+        },
+        ParcelBoundaryHoc({
+            name: (props: Object) => props.parcelName
+        })
+    ).dive().props();
+
+    // parcel has correct contents
+    expect(propsGivenToInnerComponent.testParcel.value).toBe(789);
+
+    // parcel is passed through parcel boundary as evidenced by "~bs" in its id
+    expect(propsGivenToInnerComponent.testParcel.id.indexOf("~bs")).not.toBe(-1);
+});
+
+test('ParcelBoundaryHoc config.debounce should accept number', () => {
+    let propsGivenToParcelBoundary = shallowRenderHoc(
+        {
+            testParcel: new Parcel()
+        },
+        ParcelBoundaryHoc({
+            name: 'testParcel',
+            debounce: 100
+        })
+    ).props();
+
+    expect(propsGivenToParcelBoundary.debounce).toBe(100);
+});
+
+test('ParcelBoundaryHoc config.debounce should accept props function returning number', () => {
+    let propsGivenToParcelBoundary = shallowRenderHoc(
+        {
+            testParcel: new Parcel(),
+            debounce: 100
+        },
+        ParcelBoundaryHoc({
+            name: 'testParcel',
+            debounce: (props) => props.debounce
+        })
+    ).props();
+
+    expect(propsGivenToParcelBoundary.debounce).toBe(100);
+});
+
+test('ParcelBoundaryHoc config.hold should accept number', () => {
+    let propsGivenToParcelBoundary = shallowRenderHoc(
+        {
+            testParcel: new Parcel()
+        },
+        ParcelBoundaryHoc({
+            name: 'testParcel',
+            hold: true
+        })
+    ).props();
+
+    expect(propsGivenToParcelBoundary.hold).toBe(true);
+});
+
+test('ParcelBoundaryHoc config.hold should accept props function returning number', () => {
+    let propsGivenToParcelBoundary = shallowRenderHoc(
+        {
+            testParcel: new Parcel(),
+            hold: true
+        },
+        ParcelBoundaryHoc({
+            name: 'testParcel',
+            hold: (props) => props.hold
+        })
+    ).props();
+
+    expect(propsGivenToParcelBoundary.hold).toBe(true);
+});
+
+test('ParcelBoundaryHoc config.debugBuffer should accept number', () => {
+    let propsGivenToParcelBoundary = shallowRenderHoc(
+        {
+            testParcel: new Parcel()
+        },
+        ParcelBoundaryHoc({
+            name: 'testParcel',
+            debugBuffer: true
+        })
+    ).props();
+
+    expect(propsGivenToParcelBoundary.debugBuffer).toBe(true);
+});
+
+test('ParcelBoundaryHoc should be not use pure rendering', () => {
+    let propsGivenToParcelBoundary = shallowRenderHoc(
+        {
+            testParcel: new Parcel()
+        },
+        ParcelBoundaryHoc({
+            name: 'testParcel'
+        })
+    ).props();
+
+    expect(propsGivenToParcelBoundary.pure).toBe(false);
+});
+
+test('ParcelBoundaryHoc config should optionally allow originalParcelProp to pass down original parcel', () => {
+    let testParcel = new Parcel({
+        value: 789
+    });
+
+    let propsGivenToInnerComponent = shallowRenderHoc(
+        {
+            testParcel
+        },
+        ParcelBoundaryHoc({
+            name: 'testParcel',
+            originalParcelProp: 'originalParcel'
+        })
+    ).dive().props();
+
+    expect(propsGivenToInnerComponent.originalParcel).toBe(testParcel);
+});

--- a/packages/react-dataparcels/src/__test__/ParcelBoundaryHoc-test.js
+++ b/packages/react-dataparcels/src/__test__/ParcelBoundaryHoc-test.js
@@ -26,6 +26,23 @@ test('ParcelBoundaryHoc config should pass props through', () => {
     expect(propsGivenToInnerComponent.def).toBe(456);
 });
 
+
+test('ParcelBoundaryHoc config should pass props through with no parcel found', () => {
+    let propsGivenToInnerComponent = shallowRenderHoc(
+        {
+            abc: 123,
+            def: 456
+        },
+        ParcelBoundaryHoc({
+            name: 'testParcel'
+        })
+    ).dive().props();
+
+    expect(propsGivenToInnerComponent.abc).toBe(123);
+    expect(propsGivenToInnerComponent.def).toBe(456);
+});
+
+
 test('ParcelBoundaryHoc config should pass ParcelBoundary parcel down under same prop name', () => {
     let propsGivenToInnerComponent = shallowRenderHoc(
         {

--- a/packages/react-dataparcels/src/index.js
+++ b/packages/react-dataparcels/src/index.js
@@ -24,3 +24,4 @@ export type {Property} from 'dataparcels';
 
 export {default as ParcelHoc} from './ParcelHoc';
 export {default as ParcelBoundary} from './ParcelBoundary';
+export {default as ParcelBoundaryHoc} from './ParcelBoundaryHoc';


### PR DESCRIPTION
## dataparcels

- refactor: allow for types to accept arrays

## react-dataparcels

- refactor: allow for types to accept arrays
- Add `ParcelBoundaryHoc` (https://github.com/blueflag/dataparcels/issues/108)

## dataparcels-docs

- Add `ParcelBoundaryHoc` docs
- Add child props to `ParcelHoc` and `ParcelBoundaryHoc`
