### PR TITLE
Unmutable upgrade and logging

### DIFF
--- a/packages/dataparcels-docs/src/component/ApiPage.jsx
+++ b/packages/dataparcels-docs/src/component/ApiPage.jsx
@@ -1,6 +1,7 @@
 // @flow
 import type {Node} from 'react';
 import React from 'react';
+import {Fragment} from 'react';
 import {Box, Grid, GridItem, NavigationList, NavigationListItem, Text, Typography} from 'dcme-style';
 import Link from 'component/Link';
 import SiteNavigation from 'component/SiteNavigation';
@@ -64,10 +65,18 @@ export default ({name, api, md, after}: Props) => {
             {renderDoclets({api, md})}
             {After && <Typography><After /></Typography>}
         </Box>}
-        nav={() => <NavigationList>
-            <NavigationListItem><Link to="/api">Api</Link></NavigationListItem>
-            <NavigationListItem>{name}</NavigationListItem>
-            {renderApi(api)}
-        </NavigationList>}
+        nav={() => <Fragment>
+            <NavigationList>
+                <NavigationListItem><Link to="/api">Api</Link></NavigationListItem>
+                <NavigationListItem><Link to="/api/Parcel">Parcel</Link></NavigationListItem>
+                <NavigationListItem><Link to="/api/ParcelHoc">ParcelHoc</Link></NavigationListItem>
+                <NavigationListItem><Link to="/api/ParcelBoundary">ParcelBoundary</Link></NavigationListItem>
+                <NavigationListItem><Link to="/api/ParcelBoundaryHoc">ParcelBoundaryHoc</Link></NavigationListItem>
+            </NavigationList>
+            <NavigationList>
+                <NavigationListItem>{name}</NavigationListItem>
+                {renderApi(api)}
+            </NavigationList>
+        </Fragment>}
     />;
 };

--- a/packages/dataparcels-docs/src/docs/api/parcel/log.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/log.md
@@ -1,3 +1,5 @@
 ```flow
 log(name: string?): Parcel
 ```
+
+Output's the parcel's data to the console each time data flows downward, and outputs the ChangeRequest each time a change has propagated upward.

--- a/packages/dataparcels-docs/src/docs/api/parcel/toConsole.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/toConsole.md
@@ -1,0 +1,5 @@
+```flow
+toConsole(): void
+```
+
+Outputs the parcel's data to the console.

--- a/packages/dataparcels-docs/src/docs/api/parcelBoundary/ParcelBoundary.md
+++ b/packages/dataparcels-docs/src/docs/api/parcelBoundary/ParcelBoundary.md
@@ -29,6 +29,7 @@ import {ParcelBoundary} from 'react-dataparcels';
     forceUpdate={?Array<*>}
     hold={?boolean}
     debugBuffer={?boolean}
+    debugParcel={?boolean}
 >
     {(parcel, actions) => Node}
 </ParcelBoundary>

--- a/packages/dataparcels-docs/src/docs/api/parcelBoundary/debugParcel.md
+++ b/packages/dataparcels-docs/src/docs/api/parcelBoundary/debugParcel.md
@@ -1,0 +1,5 @@
+```flow
+debugParcel?: boolean = false // optional
+```
+
+Wehn `debugParcel` is true, ParcelBoundary will log out changes to its current parcel state.

--- a/packages/dataparcels-docs/src/docs/api/parcelBoundaryHoc/ParcelBoundaryHoc.md
+++ b/packages/dataparcels-docs/src/docs/api/parcelBoundaryHoc/ParcelBoundaryHoc.md
@@ -31,6 +31,7 @@ ParcelBoundaryHoc({
     originalParcelProp?: string | (props: *) => string,
     // debugging options
     debugBuffer?: boolean
+    debugParcel?: boolean
 });
 ```
 

--- a/packages/dataparcels-docs/src/docs/api/parcelBoundaryHoc/debugParcel.md
+++ b/packages/dataparcels-docs/src/docs/api/parcelBoundaryHoc/debugParcel.md
@@ -1,0 +1,5 @@
+```flow
+debugParcel?: boolean = false // optional
+```
+
+Wehn `debugParcel` is true, ParcelBoundaryHoc will log out changes to its current parcel state.

--- a/packages/dataparcels-docs/src/docs/api/parcelHoc/ParcelHoc.md
+++ b/packages/dataparcels-docs/src/docs/api/parcelHoc/ParcelHoc.md
@@ -27,6 +27,7 @@ ParcelHoc({
     delayUntil?: Function,
     pipe?: Function
     // debugging options
+    debugParcel?: boolean
     debugRender?: boolean
 });
 ```

--- a/packages/dataparcels-docs/src/docs/api/parcelHoc/debugParcel.md
+++ b/packages/dataparcels-docs/src/docs/api/parcelHoc/debugParcel.md
@@ -1,0 +1,7 @@
+import Link from 'component/Link';
+
+```flow
+debugParcel?: boolean = false // optional
+```
+
+For debugging purposes. When set to `true` this logs the ParcelHoc's parcel each time it changes.

--- a/packages/dataparcels-docs/src/pages/api/Parcel.jsx
+++ b/packages/dataparcels-docs/src/pages/api/Parcel.jsx
@@ -59,6 +59,7 @@ import Markdown_spy from 'docs/api/parcel/spy.md';
 import Markdown_spyChange from 'docs/api/parcel/spyChange.md';
 import Markdown_pipe from 'docs/api/parcel/pipe.md';
 import Markdown_matchPipe from 'docs/api/parcel/matchPipe.md';
+import Markdown_toConsole from 'docs/api/parcel/toConsole.md';
 
 const md = {
     _desc: Markdown_Parcel,
@@ -117,7 +118,8 @@ const md = {
     spy: Markdown_spy,
     spyChange: Markdown_spyChange,
     pipe: Markdown_pipe,
-    matchPipe: Markdown_matchPipe
+    matchPipe: Markdown_matchPipe,
+    toConsole: Markdown_toConsole
 }
 
 const api = `
@@ -191,13 +193,16 @@ isTopLevel()
 hasDispatched()
 
 # Side-effect methods
-log()
 spy()
 spyChange()
 
 # Composition methods
 pipe()
 matchPipe()
+
+# Debug methods
+log()
+toConsole()
 
 `;
 

--- a/packages/dataparcels-docs/src/pages/api/ParcelBoundary.jsx
+++ b/packages/dataparcels-docs/src/pages/api/ParcelBoundary.jsx
@@ -11,6 +11,7 @@ import Markdown_debounce from 'docs/api/parcelBoundary/debounce.md';
 import Markdown_hold from 'docs/api/parcelBoundary/hold.md';
 import Markdown_pure from 'docs/api/parcelBoundary/pure.md';
 import Markdown_debugBuffer from 'docs/api/parcelBoundary/debugBuffer.md';
+import Markdown_debugParcel from 'docs/api/parcelBoundary/debugParcel.md';
 
 const md = {
     _desc: Markdown_ParcelBoundary,
@@ -21,7 +22,8 @@ const md = {
     debounce: Markdown_debounce,
     hold: Markdown_hold,
     pure: Markdown_pure,
-    debugBuffer: Markdown_debugBuffer
+    debugBuffer: Markdown_debugBuffer,
+    debugParcel: Markdown_debugParcel
 }
 
 const api = `
@@ -35,6 +37,7 @@ pure
 forceUpdate
 hold
 debugBuffer
+debugParcel
 `;
 
 export default () => <ApiPage

--- a/packages/dataparcels-docs/src/pages/api/ParcelBoundaryHoc.jsx
+++ b/packages/dataparcels-docs/src/pages/api/ParcelBoundaryHoc.jsx
@@ -8,6 +8,7 @@ import Markdown_originalParcelProp from 'docs/api/parcelBoundaryHoc/originalParc
 import Markdown_debounce from 'docs/api/parcelBoundaryHoc/debounce.md';
 import Markdown_hold from 'docs/api/parcelBoundaryHoc/hold.md';
 import Markdown_debugBuffer from 'docs/api/parcelBoundaryHoc/debugBuffer.md';
+import Markdown_debugParcel from 'docs/api/parcelBoundaryHoc/debugParcel.md';
 import Markdown_childName from 'docs/api/parcelBoundaryHoc/childName.md';
 import Markdown_childNameActions from 'docs/api/parcelBoundaryHoc/childNameActions.md';
 import Markdown_childOriginalParcelProp from 'docs/api/parcelBoundaryHoc/childOriginalParcelProp.md';
@@ -19,6 +20,7 @@ const md = {
     debounce: Markdown_debounce,
     hold: Markdown_hold,
     debugBuffer: Markdown_debugBuffer,
+    debugParcel: Markdown_debugParcel,
     ['${name}']: Markdown_childName,
     ['${name}Actions']: Markdown_childNameActions,
     ['${originalParcelProp}']: Markdown_childOriginalParcelProp
@@ -31,6 +33,7 @@ originalParcelProp
 debounce
 hold
 debugBuffer
+debugParcel
 
 # Child props
 $\{name\}

--- a/packages/dataparcels-docs/src/pages/api/ParcelHoc.jsx
+++ b/packages/dataparcels-docs/src/pages/api/ParcelHoc.jsx
@@ -10,6 +10,7 @@ import Markdown_valueFromProps from 'docs/api/parcelHoc/valueFromProps.md';
 import Markdown_delayUntil from 'docs/api/parcelHoc/delayUntil.md';
 import Markdown_onChange from 'docs/api/parcelHoc/onChange.md';
 import Markdown_pipe from 'docs/api/parcelHoc/pipe.md';
+import Markdown_debugParcel from 'docs/api/parcelHoc/debugParcel.md';
 import Markdown_debugRender from 'docs/api/parcelHoc/debugRender.md';
 import Markdown_childName from 'docs/api/parcelHoc/childName.md';
 
@@ -22,6 +23,7 @@ const md = {
     delayUntil: Markdown_delayUntil,
     onChange: Markdown_onChange,
     pipe: Markdown_pipe,
+    debugParcel: Markdown_debugParcel,
     debugRender: Markdown_debugRender,
     ['${name}']: Markdown_childName
 }
@@ -34,6 +36,7 @@ onChange
 shouldParcelUpdateFromProps
 delayUntil
 pipe
+debugParcel
 debugRender
 
 # Child props

--- a/packages/dataparcels/package.json
+++ b/packages/dataparcels/package.json
@@ -23,6 +23,6 @@
   },
   "dependencies": {
     "escape-string-regexp": "^1.0.5",
-    "unmutable": "^0.34.0"
+    "unmutable": "^0.37.0"
   }
 }

--- a/packages/dataparcels/src/parcel/Parcel.js
+++ b/packages/dataparcels/src/parcel/Parcel.js
@@ -365,4 +365,7 @@ export default class Parcel {
     // Advanced methods
     getInternalLocationShareData = (): * => this._methods.getInternalLocationShareData();
     setInternalLocationShareData = (partialData: Object): * => this._methods.setInternalLocationShareData(partialData);
+
+    // Debug methods
+    toConsole = () => this._methods.toConsole();
 }

--- a/packages/dataparcels/src/parcel/__test__/ParcelTypes-test.js
+++ b/packages/dataparcels/src/parcel/__test__/ParcelTypes-test.js
@@ -18,12 +18,12 @@ test('ParcelTypes should correctly identify date', () => {
     var data = {
         value: new Date()
     };
-    expect(new Parcel(data).isParent()).toBe(true);
+    expect(new Parcel(data).isParent()).toBe(false);
     expect(new Parcel(data).isIndexed()).toBe(false);
     expect(new Parcel(data).isChild()).toBe(false);
     expect(new Parcel(data).isElement()).toBe(false);
     expect(new Parcel(data).isTopLevel()).toBe(true);
-    expect(new Parcel(data)._parcelTypes.toTypeCode()).toBe("ceiPT");
+    expect(new Parcel(data)._parcelTypes.toTypeCode()).toBe("ceipT");
 });
 
 test('ParcelTypes should correctly identify object values', () => {
@@ -47,6 +47,22 @@ test('ParcelTypes should correctly identify class instance values', () => {
     var data = {
         value: new Thing()
     };
+    expect(new Parcel(data).isParent()).toBe(false);
+    expect(new Parcel(data).isIndexed()).toBe(false);
+    expect(new Parcel(data).isChild()).toBe(false);
+    expect(new Parcel(data).isElement()).toBe(false);
+    expect(new Parcel(data).isTopLevel()).toBe(true);
+    expect(new Parcel(data)._parcelTypes.toTypeCode()).toBe("ceipT");
+});
+
+test('ParcelTypes should correctly identify unmutable compatible class instance values', () => {
+    class UnmutableCompatible {
+        __UNMUTABLE_COMPATIBLE__ = true;
+        foo = "123";
+    }
+    var data = {
+        value: new UnmutableCompatible()
+    };
     expect(new Parcel(data).isParent()).toBe(true);
     expect(new Parcel(data).isIndexed()).toBe(false);
     expect(new Parcel(data).isChild()).toBe(false);
@@ -54,6 +70,7 @@ test('ParcelTypes should correctly identify class instance values', () => {
     expect(new Parcel(data).isTopLevel()).toBe(true);
     expect(new Parcel(data)._parcelTypes.toTypeCode()).toBe("ceiPT");
 });
+
 
 test('ParcelTypes should correctly identify Immutable.js Map values', () => {
     var data = {

--- a/packages/dataparcels/src/parcel/methods/ParcelGetMethods.js
+++ b/packages/dataparcels/src/parcel/methods/ParcelGetMethods.js
@@ -92,7 +92,7 @@ export default (_this: Parcel) => ({
         _this._log = true;
         _this._logName = name;
         console.log(`Parcel data: ${name} `);
-        console.log(JSON.parse(JSON.stringify(_this.data)));
+        _this.toConsole();
         return _this;
     },
 
@@ -111,5 +111,11 @@ export default (_this: Parcel) => ({
                 _this.dispatch(changeRequest);
             }
         });
+    },
+
+    // Debug methods
+
+    toConsole: () => {
+        console.log(JSON.parse(JSON.stringify(_this.data)));
     }
 });

--- a/packages/dataparcels/src/parcelData/isIndexedValue.js
+++ b/packages/dataparcels/src/parcelData/isIndexedValue.js
@@ -1,6 +1,7 @@
 // @flow
 import isIndexed from 'unmutable/lib/util/isIndexed';
+import isWriteable from 'unmutable/lib/util/isWriteable';
 
 export default (value: *): boolean => {
-    return isIndexed(value);
+    return isIndexed(value) && isWriteable(value);
 };

--- a/packages/dataparcels/src/parcelData/isParentValue.js
+++ b/packages/dataparcels/src/parcelData/isParentValue.js
@@ -1,6 +1,7 @@
 // @flow
 import isValueObject from 'unmutable/lib/util/isValueObject';
+import isWriteable from 'unmutable/lib/util/isWriteable';
 
 export default (value: *): boolean => {
-    return isValueObject(value);
+    return isValueObject(value) && isWriteable(value);
 };

--- a/packages/react-dataparcels/package.json
+++ b/packages/react-dataparcels/package.json
@@ -23,6 +23,6 @@
   },
   "dependencies": {
     "dataparcels": "^0.16.0-0",
-    "unmutable": "^0.34.0"
+    "unmutable": "^0.37.0"
   }
 }

--- a/packages/react-dataparcels/src/ParcelBoundary.jsx
+++ b/packages/react-dataparcels/src/ParcelBoundary.jsx
@@ -7,6 +7,8 @@ import type {ChangeRequest} from 'dataparcels';
 import ParcelBoundaryEquals from './util/ParcelBoundaryEquals';
 import shallowEquals from 'unmutable/lib/shallowEquals';
 
+const log = (...args) => console.log(`ParcelBoundary:`, ...args);
+
 type Actions = {
     release: Function
 };
@@ -17,6 +19,7 @@ type Props = {
     children: RenderFunction,
     debounce: number,
     debugBuffer: boolean,
+    debugParcel: boolean,
     hold: boolean,
     forceUpdate: Array<*>,
     parcel: Parcel,
@@ -35,6 +38,7 @@ export default class ParcelBoundary extends React.Component<Props, State> { /* e
     static defaultProps: * = {
         debounce: 0,
         debugBuffer: false,
+        debugParcel: false,
         hold: false,
         forceUpdate: [],
         pure: true
@@ -45,6 +49,11 @@ export default class ParcelBoundary extends React.Component<Props, State> { /* e
         this.state = {
             parcel: this.makeBoundarySplit(props.parcel)
         };
+
+        if(props.debugParcel) {
+            log(`Received initial value`);
+            props.parcel.toConsole();
+        }
     }
 
     shouldComponentUpdate(nextProps: Props, nextState: State): boolean {
@@ -67,6 +76,11 @@ export default class ParcelBoundary extends React.Component<Props, State> { /* e
             this.setState({
                 parcel: this.makeBoundarySplit(parcel)
             });
+
+            if(nextProps.debugParcel) {
+                log(`Parcel replaced from props:`);
+                parcel.toConsole();
+            }
         }
     }
 
@@ -94,7 +108,12 @@ export default class ParcelBoundary extends React.Component<Props, State> { /* e
     };
 
     cancelBuffer: Function = () => {
-        let {debugBuffer, parcel} = this.props;
+        let {
+            debugBuffer,
+            debugParcel,
+            parcel
+        } = this.props;
+
         if(debugBuffer) {
             console.log("ParcelBoundary: Clear buffer:");
             this.cachedChangeRequest && this.cachedChangeRequest.toConsole();
@@ -106,6 +125,11 @@ export default class ParcelBoundary extends React.Component<Props, State> { /* e
         this.setState({
             parcel: this.makeBoundarySplit(parcel)
         });
+
+        if(debugParcel) {
+            log(`Buffer cancelled. Parcel reverted:`);
+            parcel.toConsole();
+        }
     };
 
     releaseBuffer: Function = () => {
@@ -122,6 +146,7 @@ export default class ParcelBoundary extends React.Component<Props, State> { /* e
     };
 
     makeBoundarySplit: Function = (parcel: Parcel): Parcel => {
+        let {debugParcel} = this.props;
         return parcel._boundarySplit({
             handleChange: (newParcel: Parcel, changeRequest: ChangeRequest) => {
                 let {
@@ -132,6 +157,11 @@ export default class ParcelBoundary extends React.Component<Props, State> { /* e
                 this.setState({
                     parcel: newParcel
                 });
+
+                if(debugParcel) {
+                    log(`Parcel changed:`);
+                    newParcel.toConsole();
+                }
 
                 this.addToBuffer(changeRequest);
 

--- a/packages/react-dataparcels/src/ParcelBoundaryHoc.jsx
+++ b/packages/react-dataparcels/src/ParcelBoundaryHoc.jsx
@@ -21,7 +21,8 @@ type ParcelBoundaryHocConfig = {
     debounce?: number|(props: *) => number,
     hold?: boolean|(props: *) => boolean,
     originalParcelProp?: string|(props: *) => string,
-    debugBuffer?: boolean
+    debugBuffer?: boolean,
+    debugParcel?: boolean
 };
 
 const PARCEL_BOUNDARY_HOC_NAME = `ParcelBoundaryHoc()`;
@@ -43,11 +44,13 @@ export default (config: ParcelBoundaryHocConfig): Function => {
             // $FlowFixMe
             let originalParcelProp: ?string = fromProps(config.originalParcelProp);
             let debugBuffer: boolean = config.debugBuffer || false;
+            let debugParcel: boolean = config.debugParcel || false;
 
             Types(PARCEL_BOUNDARY_HOC_NAME, "config.name", "string")(name);
             debounce && Types(PARCEL_BOUNDARY_HOC_NAME, "config.debounce", "number")(debounce);
             Types(PARCEL_BOUNDARY_HOC_NAME, "config.hold", "boolean")(hold);
             Types(PARCEL_BOUNDARY_HOC_NAME, "config.debugBuffer", "boolean")(debugBuffer);
+            Types(PARCEL_BOUNDARY_HOC_NAME, "config.debugParcel", "boolean")(debugParcel);
             originalParcelProp && Types(PARCEL_BOUNDARY_HOC_NAME, "config.originalParcelProp", "string")(originalParcelProp);
 
             let parcel = this.props[name];
@@ -62,6 +65,7 @@ export default (config: ParcelBoundaryHocConfig): Function => {
                 debounce={debounce}
                 hold={hold}
                 debugBuffer={debugBuffer}
+                debugParcel={debugParcel}
                 pure={false}
             >
                 {(innerParcel, actions) => {

--- a/packages/react-dataparcels/src/ParcelHoc.jsx
+++ b/packages/react-dataparcels/src/ParcelHoc.jsx
@@ -24,6 +24,7 @@ type ParcelHocConfig = {
     delayUntil?: (props: *) => boolean,
     onChange?: (props: *) => (parcel: Parcel, changeRequest: ChangeRequest) => void,
     pipe?: (props: *) => (parcel: Parcel) => Parcel,
+    debugParcel?: boolean,
     debugRender?: boolean
 };
 
@@ -40,6 +41,7 @@ export default (config: ParcelHocConfig): Function => {
         onChange = (props) => (value, changeRequest) => undefined, /* eslint-disable-line no-unused-vars */
         pipe = props => ii => ii, /* eslint-disable-line no-unused-vars */
         // debug options
+        debugParcel = false,
         debugRender = false
     } = config;
 
@@ -48,6 +50,7 @@ export default (config: ParcelHocConfig): Function => {
     Types(PARCEL_HOC_NAME, "config.delayUntil", "function")(delayUntil);
     Types(PARCEL_HOC_NAME, "config.onChange", "function")(onChange);
     Types(PARCEL_HOC_NAME, "config.pipe", "function")(pipe);
+    Types(PARCEL_HOC_NAME, "config.debugParcel", "boolean")(debugParcel);
     Types(PARCEL_HOC_NAME, "config.debugRender", "boolean")(debugRender);
 
     return (Component: ComponentType<ChildProps>) => class ParcelHoc extends React.Component<Props, State> {
@@ -75,6 +78,11 @@ export default (config: ParcelHocConfig): Function => {
                 let value = valueFromProps(props);
                 newState.prevValueFromProps = value;
                 newState.parcel = state.initialize(value);
+
+                if(debugParcel) {
+                    console.log(`Parcel received initial value:`);
+                    newState.parcel.toConsole();
+                }
             }
 
             if(parcel && shouldParcelUpdateFromProps) {
@@ -85,6 +93,11 @@ export default (config: ParcelHocConfig): Function => {
                     newState.parcel = parcel.batchAndReturn((parcel: Parcel) => {
                         parcel.set(value);
                     });
+
+                    if(debugParcel) {
+                        console.log(`Parcel updated from props:`);
+                        newState.parcel.toConsole();
+                    }
                 }
             }
 
@@ -93,6 +106,11 @@ export default (config: ParcelHocConfig): Function => {
 
         handleChange = (parcel, changeRequest) => {
             this.setState({parcel});
+            if(debugParcel) {
+                console.log(`Parcel changed:`);
+                parcel.toConsole();
+            }
+
             let onChangeWithProps = onChange(this.props);
             Types(`handleChange()`, "return value of onChange", "function")(onChangeWithProps);
             onChangeWithProps(parcel.value, changeRequest);

--- a/packages/react-dataparcels/src/ParcelHoc.jsx
+++ b/packages/react-dataparcels/src/ParcelHoc.jsx
@@ -7,6 +7,8 @@ import React from 'react';
 import Parcel from 'dataparcels';
 import Types from 'dataparcels/lib/types/Types';
 
+const log = (...args) => console.log(`ParcelHoc:`, ...args);
+
 type Props = {};
 type State = {
     parcel: ?Parcel,
@@ -80,7 +82,7 @@ export default (config: ParcelHocConfig): Function => {
                 newState.parcel = state.initialize(value);
 
                 if(debugParcel) {
-                    console.log(`Parcel received initial value:`);
+                    log(`Received initial value:`);
                     newState.parcel.toConsole();
                 }
             }
@@ -95,7 +97,7 @@ export default (config: ParcelHocConfig): Function => {
                     });
 
                     if(debugParcel) {
-                        console.log(`Parcel updated from props:`);
+                        log(`Parcel updated from props:`);
                         newState.parcel.toConsole();
                     }
                 }
@@ -107,7 +109,7 @@ export default (config: ParcelHocConfig): Function => {
         handleChange = (parcel, changeRequest) => {
             this.setState({parcel});
             if(debugParcel) {
-                console.log(`Parcel changed:`);
+                log(`Parcel changed:`);
                 parcel.toConsole();
             }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12305,9 +12305,9 @@ unmutable@0.29.2, unmutable@^0.29.2:
     fast-deep-equal "^1.0.0"
     is-plain-object "^2.0.4"
 
-unmutable@^0.34.0:
-  version "0.34.0"
-  resolved "https://registry.yarnpkg.com/unmutable/-/unmutable-0.34.0.tgz#512ad3f5286215cab8ce554741d42c2ca8822a70"
+unmutable@^0.37.0:
+  version "0.37.0"
+  resolved "https://registry.yarnpkg.com/unmutable/-/unmutable-0.37.0.tgz#728dc1d503206475d4ab49d72e4b16adb69a3c8f"
   dependencies:
     fast-deep-equal "^1.0.0"
     is-plain-object "^2.0.4"


### PR DESCRIPTION
## dataparcels

- add `Parcel.toConsole`
- fix #122 only unmutable writeable data types are now considered parent parcel types
  - this is because it doesn't make sense to allow people to `get()` something that cannot be `set`
- feat: upgrade unmutable, unmutable compatible classes are now permitted as editable parent values

## react-dataparcels

- add `ParcelHoc` `config.debugParcel` #86 
- add `ParcelBoundary` `debugParcel`
- add `ParcelBoundaryHoc` `config.debugParcel`