### PR TITLE
Fix: remove errors thrown by reducer from missing keys

### DIFF
--- a/packages/dataparcels/src/change/Reducer.js
+++ b/packages/dataparcels/src/change/Reducer.js
@@ -3,7 +3,6 @@ import type {Index} from '../types/Types';
 import type {Key} from '../types/Types';
 import type {ParcelData} from '../types/Types';
 
-import {ReducerKeyPathRequiredError} from '../errors/Errors';
 import {ReducerInvalidActionError} from '../errors/Errors';
 import {ReducerSwapKeyError} from '../errors/Errors';
 
@@ -69,7 +68,7 @@ function Reducer(parcelData: ParcelData, action: Action|Action[]): ParcelData {
 
         case "insertAfter": {
             if(keyPathIsEmpty) {
-                throw ReducerKeyPathRequiredError(type);
+                return parcelData;
             }
             return updateIn(
                 keyPathButLast,
@@ -79,7 +78,7 @@ function Reducer(parcelData: ParcelData, action: Action|Action[]): ParcelData {
 
         case "insertBefore": {
             if(keyPathIsEmpty) {
-                throw ReducerKeyPathRequiredError(type);
+                return parcelData;
             }
             return updateIn(
                 keyPathButLast,
@@ -136,7 +135,7 @@ function Reducer(parcelData: ParcelData, action: Action|Action[]): ParcelData {
 
         case "swap": {
             if(keyPathIsEmpty) {
-                throw ReducerKeyPathRequiredError(type);
+                return parcelData;
             }
             let {swapKey} = action.payload;
             if(typeof swapKey === "undefined") {
@@ -151,7 +150,7 @@ function Reducer(parcelData: ParcelData, action: Action|Action[]): ParcelData {
 
         case "swapNext": {
             if(keyPathIsEmpty) {
-                throw ReducerKeyPathRequiredError(type);
+                return parcelData;
             }
 
             return updateIn(
@@ -162,7 +161,7 @@ function Reducer(parcelData: ParcelData, action: Action|Action[]): ParcelData {
 
         case "swapPrev": {
             if(keyPathIsEmpty) {
-                throw ReducerKeyPathRequiredError(type);
+                return parcelData;
             }
 
             return updateIn(

--- a/packages/dataparcels/src/change/__test__/ReducerIndexed-test.js
+++ b/packages/dataparcels/src/change/__test__/ReducerIndexed-test.js
@@ -2,7 +2,6 @@
 
 import Reducer from '../Reducer';
 import Action from '../Action';
-// import prepareChildKeys from '../../parcelData/prepareChildKeys';
 
 let data = {
     value: [0,1,2],
@@ -22,8 +21,8 @@ let EXPECTED_KEY_AND_META = {
     "swapNext",
     "swapPrev"
 ].forEach((type: string) => {
-    test(`Reducer ${type} action should throw error if keyPath is empty`, () => {
-        expect(() => Reducer(data, new Action({type}))).toThrowError(`${type} actions must have a keyPath with at least one key`);
+    test(`Reducer ${type} action should return unchanged parcelData if keyPath is empty`, () => {
+        expect(Reducer(data, new Action({type}))).toEqual(data);
     });
 });
 

--- a/packages/dataparcels/src/errors/Errors.js
+++ b/packages/dataparcels/src/errors/Errors.js
@@ -1,6 +1,5 @@
 // @flow
 
 export const ReadOnlyError = () => new Error(`This property is read-only`);
-export const ReducerKeyPathRequiredError = (actionType: string) => new Error(`${actionType} actions must have a keyPath with at least one key`);
 export const ReducerInvalidActionError = (actionType: string) => new Error(`"${actionType}" is not a valid action`);
 export const ReducerSwapKeyError = () =>  new Error(`swap actions must have a swapKey in their payload`);


### PR DESCRIPTION
Last release introduced a bug where `insertAfter`, `insertBefore`, `swap `, `swapNext` and `swapPrev` on element parcel directly inside a `ParcelBoundary` would error out, because these actions were set to throw errors when not enough keys were provided in the actions `keyPath`. At the time these action are called that is correct, there aren't enough keys provided for a meaningful change of data to take place, at least not until the change propagates up to the parent. The `ParcelBoundary` ran each of these through the reducer while having "not enough keys", and this resulted in an error that would also have been previously caught in an empty try catch block that used to be around the reducer, presumably for this purpose.

It's more correct for the reducer to return the unchanged data of the element in question, rather than throwing an error.