### PR TITLE
Feature/buffer boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-![dataparcels](https://user-images.githubusercontent.com/345320/46786065-80c90b00-cd7f-11e8-8d59-abf6aec965bf.png)
+![dataparcels](https://user-images.githubusercontent.com/345320/48319791-4eece200-e666-11e8-8b19-252cd1135ae2.png)
 
-<a href="https://www.npmjs.com/package/react-router"><img src="https://img.shields.io/npm/v/dataparcels.svg?style=flat-square"></a>
+<a href="https://www.npmjs.com/package/react-dataparcels"><img src="https://img.shields.io/npm/v/dataparcels.svg?style=flat-square"></a>
 [![CircleCI](https://circleci.com/gh/blueflag/dataparcels/tree/master.svg?style=shield)](https://circleci.com/gh/blueflag/dataparcels/tree/master)
 
 A library for editing data structures that works really well with React.

--- a/packages/dataparcels-docs/src/component/ApiPage.jsx
+++ b/packages/dataparcels-docs/src/component/ApiPage.jsx
@@ -68,10 +68,10 @@ export default ({name, api, md, after}: Props) => {
         nav={() => <Fragment>
             <NavigationList>
                 <NavigationListItem><Link to="/api">Api</Link></NavigationListItem>
-                <NavigationListItem><Link to="/api/Parcel">Parcel</Link></NavigationListItem>
-                <NavigationListItem><Link to="/api/ParcelHoc">ParcelHoc</Link></NavigationListItem>
-                <NavigationListItem><Link to="/api/ParcelBoundary">ParcelBoundary</Link></NavigationListItem>
-                <NavigationListItem><Link to="/api/ParcelBoundaryHoc">ParcelBoundaryHoc</Link></NavigationListItem>
+                <NavigationListItem>1. <Link to="/api/Parcel">Parcel</Link></NavigationListItem>
+                <NavigationListItem>2. <Link to="/api/ParcelHoc">ParcelHoc</Link></NavigationListItem>
+                <NavigationListItem>3. <Link to="/api/ParcelBoundary">ParcelBoundary</Link></NavigationListItem>
+                <NavigationListItem>4. <Link to="/api/ParcelBoundaryHoc">ParcelBoundaryHoc</Link></NavigationListItem>
             </NavigationList>
             <NavigationList>
                 <NavigationListItem>{name}</NavigationListItem>

--- a/packages/dataparcels-docs/src/docs/api/parcelBoundary/ParcelBoundary.md
+++ b/packages/dataparcels-docs/src/docs/api/parcelBoundary/ParcelBoundary.md
@@ -31,7 +31,7 @@ import {ParcelBoundary} from 'react-dataparcels';
     debugBuffer={?boolean}
     debugParcel={?boolean}
 >
-    {(parcel, actions) => Node}
+    {(parcel, actions, buffered) => Node}
 </ParcelBoundary>
 ```
 

--- a/packages/dataparcels-docs/src/docs/api/parcelBoundary/childRenderer.md
+++ b/packages/dataparcels-docs/src/docs/api/parcelBoundary/childRenderer.md
@@ -1,7 +1,7 @@
 import Link from 'component/Link';
 
 ```flow
-(parcel: Parcel, actions: ParcelBoundaryActions) => Node
+(parcel: Parcel, actions: ParcelBoundaryActions, buffered: boolean) => Node
 ```
 
 ```flow
@@ -13,8 +13,10 @@ ParcelBoundaryActions = {
 
 ParcelBoundaries must be given a `childRenderer` function as children. This is called whenever the ParcelBoundary updates.
 
-It is passed a `parcel` and a set of `actions`. The parcel is on the "inside" of the parcel boundary, and is able to update independently of the parcel that was passed into the ParcelBoundary.
-The actions can be used to control the ParcelBoundary's action buffer (see the <Link to="/examples/parcelboundary-hold">hold example</Link>). 
+It is passed a `parcel`, a set of `actions`, and a `buffered` boolean.
+- The `parcel` is on the "inside" of the parcel boundary, and is able to update independently of the parcel that was passed into the ParcelBoundary.
+- The `actions` can be used to control the ParcelBoundary's action buffer (see the <Link to="/examples/parcelboundary-hold">hold example</Link>). 
+- The `buffered` boolean indicates if the ParcelBoundary currently contains changes that it hasn't yet released.
 
 The return value of `childRenderer` will be rendered.
 

--- a/packages/dataparcels-docs/src/docs/api/parcelBoundaryHoc/childNameBuffered.md
+++ b/packages/dataparcels-docs/src/docs/api/parcelBoundaryHoc/childNameBuffered.md
@@ -1,0 +1,9 @@
+import Link from 'component/Link';
+
+```flow
+${name}Buffered: boolean
+```
+
+ParcelBoundaryHoc's child component will receive a boolean that indicates if the ParcelBoundaryHoc currently contains changes that it hasn't yet released.
+
+If ParcelBoundaryHoc doesn't receive a parcel as a prop at the name indicated by `config.name`, then this child prop will not exist.

--- a/packages/dataparcels-docs/src/layouts/index.scss
+++ b/packages/dataparcels-docs/src/layouts/index.scss
@@ -52,7 +52,15 @@
 @include DcmeText {
     &-superDuper {
         text-shadow: -6px 6px 0px darken(color('primary'), 15),
-            -12px 12px 0px darken(color('secondary'), 40)
+            -12px 12px 0px #340e57
+    }
+
+    &-superDuperReadme {
+        color: #000;
+        line-height: 4.2rem;
+        padding-left: .7rem;
+        text-shadow: -6px 6px 0px lighten(color('primary'), 10),
+            -12px 12px 0px lighten(color('primary'), 30)
     }
 }
 @include DcmeTypography;

--- a/packages/dataparcels-docs/src/pages/api/ParcelBoundaryHoc.jsx
+++ b/packages/dataparcels-docs/src/pages/api/ParcelBoundaryHoc.jsx
@@ -11,6 +11,7 @@ import Markdown_debugBuffer from 'docs/api/parcelBoundaryHoc/debugBuffer.md';
 import Markdown_debugParcel from 'docs/api/parcelBoundaryHoc/debugParcel.md';
 import Markdown_childName from 'docs/api/parcelBoundaryHoc/childName.md';
 import Markdown_childNameActions from 'docs/api/parcelBoundaryHoc/childNameActions.md';
+import Markdown_childNameBuffered from 'docs/api/parcelBoundaryHoc/childNameBuffered.md';
 import Markdown_childOriginalParcelProp from 'docs/api/parcelBoundaryHoc/childOriginalParcelProp.md';
 
 const md = {
@@ -23,6 +24,7 @@ const md = {
     debugParcel: Markdown_debugParcel,
     ['${name}']: Markdown_childName,
     ['${name}Actions']: Markdown_childNameActions,
+    ['${name}Buffered']: Markdown_childNameBuffered,
     ['${originalParcelProp}']: Markdown_childOriginalParcelProp
 }
 
@@ -38,6 +40,7 @@ debugParcel
 # Child props
 $\{name\}
 $\{name\}Actions
+$\{name\}Buffered
 $\{originalParcelProp\}
 `;
 

--- a/packages/dataparcels-docs/src/pages/logo.js
+++ b/packages/dataparcels-docs/src/pages/logo.js
@@ -1,0 +1,7 @@
+// @flow
+import type {Node} from 'react';
+
+import React from 'react';
+import {Text} from 'dcme-style';
+
+export default () => <Text element="h1" modifier="sizeTera superDuperReadme">dataparcels</Text>;

--- a/packages/dataparcels/README.md
+++ b/packages/dataparcels/README.md
@@ -1,6 +1,6 @@
-![dataparcels](https://user-images.githubusercontent.com/345320/46786065-80c90b00-cd7f-11e8-8d59-abf6aec965bf.png)
+![dataparcels](https://user-images.githubusercontent.com/345320/48319791-4eece200-e666-11e8-8b19-252cd1135ae2.png)
 
-<a href="https://www.npmjs.com/package/react-router"><img src="https://img.shields.io/npm/v/dataparcels.svg?style=flat-square"></a>
+<a href="https://www.npmjs.com/package/react-dataparcels"><img src="https://img.shields.io/npm/v/dataparcels.svg?style=flat-square"></a>
 [![CircleCI](https://circleci.com/gh/blueflag/dataparcels/tree/master.svg?style=shield)](https://circleci.com/gh/blueflag/dataparcels/tree/master)
 
 A library for editing data structures that works really well with React.

--- a/packages/react-dataparcels/README.md
+++ b/packages/react-dataparcels/README.md
@@ -1,6 +1,6 @@
-![dataparcels](https://user-images.githubusercontent.com/345320/46786065-80c90b00-cd7f-11e8-8d59-abf6aec965bf.png)
+![dataparcels](https://user-images.githubusercontent.com/345320/48319791-4eece200-e666-11e8-8b19-252cd1135ae2.png)
 
-<a href="https://www.npmjs.com/package/react-router"><img src="https://img.shields.io/npm/v/dataparcels.svg?style=flat-square"></a>
+<a href="https://www.npmjs.com/package/react-dataparcels"><img src="https://img.shields.io/npm/v/dataparcels.svg?style=flat-square"></a>
 [![CircleCI](https://circleci.com/gh/blueflag/dataparcels/tree/master.svg?style=shield)](https://circleci.com/gh/blueflag/dataparcels/tree/master)
 
 A library for editing data structures that works really well with React.

--- a/packages/react-dataparcels/src/ParcelBoundary.jsx
+++ b/packages/react-dataparcels/src/ParcelBoundary.jsx
@@ -7,13 +7,16 @@ import type {ChangeRequest} from 'dataparcels';
 import ParcelBoundaryEquals from './util/ParcelBoundaryEquals';
 import shallowEquals from 'unmutable/lib/shallowEquals';
 
+import set from 'unmutable/lib/set';
+import pipe from 'unmutable/lib/util/pipe';
+
 const log = (...args) => console.log(`ParcelBoundary:`, ...args);
 
 type Actions = {
     release: Function
 };
 
-type RenderFunction = (parcel: Parcel, actions: Actions) => Node;
+type RenderFunction = (parcel: Parcel, actions: Actions, buffered: boolean) => Node;
 
 type Props = {
     children: RenderFunction,
@@ -27,13 +30,14 @@ type Props = {
 };
 
 type State = {
-    parcel: Parcel
+    cachedChangeRequest: ?ChangeRequest,
+    changeCount: number,
+    makeBoundarySplit: Function,
+    parcel: Parcel,
+    parcelFromProps: Parcel
 };
 
 export default class ParcelBoundary extends React.Component<Props, State> { /* eslint-disable-line react/no-deprecated */
-
-    cachedChangeRequest: ?ChangeRequest;
-    changeCount: number = 0;
 
     static defaultProps: * = {
         debounce: 0,
@@ -46,8 +50,15 @@ export default class ParcelBoundary extends React.Component<Props, State> { /* e
 
     constructor(props: Props) {
         super(props);
+
+        let parcel = this.makeBoundarySplit(props.parcel);
+
         this.state = {
-            parcel: this.makeBoundarySplit(props.parcel)
+            cachedChangeRequest: undefined,
+            changeCount: 0,
+            makeBoundarySplit: this.makeBoundarySplit,
+            parcel,
+            parcelFromProps: parcel
         };
 
         if(props.debugParcel) {
@@ -61,26 +72,42 @@ export default class ParcelBoundary extends React.Component<Props, State> { /* e
             return true;
         }
 
-        let parcelDataChanged: boolean = (nextProps.debounce || nextProps.hold)
-            ? !ParcelBoundaryEquals(this.state.parcel, nextState.parcel)
-            : !ParcelBoundaryEquals(this.props.parcel, nextProps.parcel);
+        let parcelDataChanged: boolean = !ParcelBoundaryEquals(this.props.parcel, nextProps.parcel);
+
+        if(!parcelDataChanged && (nextProps.debounce || nextProps.hold)) {
+            parcelDataChanged = !ParcelBoundaryEquals(this.state.parcel, nextState.parcel);
+        }
 
         let forceUpdateChanged: boolean = !shallowEquals(this.props.forceUpdate)(nextProps.forceUpdate);
-        return parcelDataChanged || forceUpdateChanged;
+        let cachedChangeRequestChanged: boolean = this.state.cachedChangeRequest !== nextState.cachedChangeRequest;
+
+        return parcelDataChanged || forceUpdateChanged || cachedChangeRequestChanged;
     }
 
-    componentWillReceiveProps(nextProps: Object) {
-        let {parcel} = nextProps;
-        if(!ParcelBoundaryEquals(this.props.parcel, parcel)) {
-            this.cachedChangeRequest = undefined;
-            this.setState({
-                parcel: this.makeBoundarySplit(parcel)
-            });
+    static getDerivedStateFromProps(props: Props, state: State): * {
+        let {parcel} = props;
+        let {
+            makeBoundarySplit,
+            parcelFromProps
+        } = state;
 
-            if(nextProps.debugParcel) {
-                log(`Parcel replaced from props:`);
-                parcel.toConsole();
+        if(parcel !== parcelFromProps) {
+            var newState: any = {
+                parcelFromProps: parcel
+            };
+
+            if(!ParcelBoundaryEquals(parcelFromProps, parcel)) {
+                if(props.debugParcel) {
+                    log(`Parcel replaced from props:`);
+                    parcel.toConsole();
+                }
+
+                newState.cachedChangeRequest = undefined;
+                newState.changeCount = 0;
+                newState.parcel = makeBoundarySplit(parcel);
             }
+
+            return newState;
         }
     }
 
@@ -93,112 +120,151 @@ export default class ParcelBoundary extends React.Component<Props, State> { /* e
         };
     };
 
-    addToBuffer: Function = (changeRequest: ChangeRequest) => {
+    addToBuffer: Function = (changeRequest: ChangeRequest) => (state: *) => {
         let {debugBuffer} = this.props;
+        let {
+            cachedChangeRequest,
+            changeCount
+        } = state;
+
         if(debugBuffer) {
             console.log("ParcelBoundary: Add to buffer:");
             changeRequest.toConsole();
         }
-        if(!this.cachedChangeRequest) {
-            this.cachedChangeRequest = changeRequest;
-        } else {
-            this.cachedChangeRequest = this.cachedChangeRequest.merge(changeRequest);
-        }
-        this.changeCount++;
+
+        let newCachedChangeRequest = cachedChangeRequest
+            ? cachedChangeRequest.merge(changeRequest)
+            : changeRequest;
+
+        return {
+            ...state,
+            cachedChangeRequest: newCachedChangeRequest,
+            changeCount: changeCount + 1
+        };
     };
 
-    cancelBuffer: Function = () => {
+    cancelBuffer: Function = () => (state: *) => {
         let {
             debugBuffer,
             debugParcel,
             parcel
         } = this.props;
 
+        let {cachedChangeRequest} = state;
+
         if(debugBuffer) {
             console.log("ParcelBoundary: Clear buffer:");
-            this.cachedChangeRequest && this.cachedChangeRequest.toConsole();
+            cachedChangeRequest && cachedChangeRequest.toConsole();
         }
-        if(!this.cachedChangeRequest) {
-            return;
+        if(!cachedChangeRequest) {
+            return state;
         }
-        this.cachedChangeRequest = undefined;
-        this.setState({
-            parcel: this.makeBoundarySplit(parcel)
-        });
 
         if(debugParcel) {
             log(`Buffer cancelled. Parcel reverted:`);
             parcel.toConsole();
         }
+
+        return {
+            ...state,
+            cachedChangeRequest: undefined,
+            changeCount: 0,
+            parcel: this.makeBoundarySplit(parcel)
+        };
     };
 
-    releaseBuffer: Function = () => {
+    releaseBuffer: Function = () => (state: *) => {
         let {debugBuffer} = this.props;
+        let {cachedChangeRequest} = state;
+
         if(debugBuffer) {
             console.log("ParcelBoundary: Release buffer:");
-            this.cachedChangeRequest && this.cachedChangeRequest.toConsole();
+            cachedChangeRequest && cachedChangeRequest.toConsole();
         }
-        if(!this.cachedChangeRequest) {
-            return;
+
+        if(!cachedChangeRequest) {
+            return state;
         }
-        this.props.parcel.dispatch(this.cachedChangeRequest);
-        this.cachedChangeRequest = undefined;
+
+        this.props.parcel.dispatch(cachedChangeRequest);
+        return {
+            ...state,
+            cachedChangeRequest: undefined,
+            changeCount: 0
+        };
     };
 
     makeBoundarySplit: Function = (parcel: Parcel): Parcel => {
-        let {debugParcel} = this.props;
         return parcel._boundarySplit({
             handleChange: (newParcel: Parcel, changeRequest: ChangeRequest) => {
                 let {
                     debounce,
+                    debugParcel,
                     hold
                 } = this.props;
 
-                this.setState({
-                    parcel: newParcel
-                });
+                let {changeCount} = this.state;
 
                 if(debugParcel) {
                     log(`Parcel changed:`);
                     newParcel.toConsole();
                 }
 
-                this.addToBuffer(changeRequest);
-
                 let shouldBeSynchronous = () => changeRequest
                     .actions()
                     .some(action => action.shouldBeSynchronous());
 
+                let updateParcel = set('parcel', newParcel);
+                let addToBuffer = this.addToBuffer(changeRequest);
+                let releaseBuffer = this.releaseBuffer();
+
                 if((!debounce && !hold) || shouldBeSynchronous()) {
-                    this.releaseBuffer();
+                    this.setState(pipe(
+                        updateParcel,
+                        addToBuffer,
+                        releaseBuffer
+                    ));
                     return;
                 }
 
                 if(hold) {
+                    this.setState(pipe(
+                        updateParcel,
+                        addToBuffer
+                    ));
                     return;
                 }
 
                 // debounce && !hold
 
-                let originalChangeCount = this.changeCount;
                 setTimeout(() => {
-                    if(originalChangeCount === this.changeCount) {
-                        this.releaseBuffer();
+                    if(changeCount + 1 === this.state.changeCount) {
+                        this.setState(releaseBuffer);
                     }
                 }, debounce);
+
+                this.setState(pipe(
+                    updateParcel,
+                    addToBuffer
+                ));
             }
         });
     };
 
     render(): Node {
         let {children} = this.props;
-        let {parcel} = this.state;
-        let actions = {
-            cancel: this.cancelBuffer,
-            release: this.releaseBuffer
-        };
+        let {
+            changeCount,
+            parcel
+        } = this.state;
 
-        let element = children(parcel, actions);
+        let actions = {
+            cancel: () => this.setState(this.cancelBuffer()),
+            release: () => this.setState(this.releaseBuffer())
+        };
+        let buffered = changeCount > 0;
+
+        let element = children(parcel, actions, buffered);
 
         if(parcel._treeshare.debugRender) {
             return <div style={this.debugRenderStyle()}>{element}</div>;

--- a/packages/react-dataparcels/src/ParcelBoundaryHoc.jsx
+++ b/packages/react-dataparcels/src/ParcelBoundaryHoc.jsx
@@ -12,6 +12,7 @@ type Props = {
 type ChildProps = {
     // [config.name]?: Parcel,
     // [config.name + "Actions"]?: Parcel,
+    // [config.name + "Buffered"]?: Parcel,
     // [config.originalParcelProp]?: Parcel
     // ...
 };
@@ -68,13 +69,15 @@ export default (config: ParcelBoundaryHocConfig): Function => {
                 debugParcel={debugParcel}
                 pure={false}
             >
-                {(innerParcel, actions) => {
+                {(innerParcel, actions, buffered) => {
                     let childProps = {
                         ...this.props,
                         // $FlowFixMe - I want to use a computed property, flow
                         [name]: innerParcel,
                         // $FlowFixMe - I want to use a computed property, flow
-                        [name + "Actions"]: actions
+                        [name + "Actions"]: actions,
+                        // $FlowFixMe - I want to use a computed property, flow
+                        [name + "Buffered"]: buffered
                     };
 
                     if(originalParcelProp) {

--- a/packages/react-dataparcels/src/__test__/ParcelBoundary-test.js
+++ b/packages/react-dataparcels/src/__test__/ParcelBoundary-test.js
@@ -158,6 +158,29 @@ test('ParcelBoundary should release changes when called', async () => {
     expect(newParcel.value).toBe(123);
 });
 
+test('ParcelBoundary should pass buffered status to childRenderer', async () => {
+    let childRenderer = jest.fn();
+
+    let parcel = new Parcel();
+
+    let wrapper = shallow(<ParcelBoundary parcel={parcel} hold>
+        {childRenderer}
+    </ParcelBoundary>);
+
+    let [childParcel, actions, buffered] = childRenderer.mock.calls[0];
+    childParcel.onChange(123);
+    // handleChange shouldn't be called yet because hold is true
+    expect(buffered).toBe(false);
+
+    let [childParcel2, actions2, buffered2] = childRenderer.mock.calls[1];
+    expect(buffered2).toBe(true);
+
+    actions.release();
+
+    let [childParcel3, actions3, buffered3] = childRenderer.mock.calls[2];
+    expect(buffered3).toBe(false);
+});
+
 test('ParcelBoundary should debounce', async () => {
     let childRenderer = jest.fn();
     let handleChange = jest.fn();

--- a/packages/react-dataparcels/src/__test__/ParcelBoundaryHoc-test.js
+++ b/packages/react-dataparcels/src/__test__/ParcelBoundaryHoc-test.js
@@ -78,6 +78,22 @@ test('ParcelBoundaryHoc config should pass actions as config.name + "Actions', (
     expect(typeof propsGivenToInnerComponent.testParcelActions.cancel).toBe("function");
 });
 
+test('ParcelBoundaryHoc config should pass buffered prop as config.name + "Buffered', () => {
+    let propsGivenToInnerComponent = shallowRenderHoc(
+        {
+            testParcel: new Parcel({
+                value: 789
+            })
+        },
+        ParcelBoundaryHoc({
+            name: 'testParcel'
+        })
+    ).dive().props();
+
+    // testParcelBuffered should contain a boolean object
+    expect(typeof propsGivenToInnerComponent.testParcelBuffered).toBe("boolean");
+});
+
 test('ParcelBoundaryHoc config.name should accept props function returning string', () => {
     let propsGivenToInnerComponent = shallowRenderHoc(
         {

--- a/packages/react-dataparcels/src/util/ParcelBoundaryEquals.js
+++ b/packages/react-dataparcels/src/util/ParcelBoundaryEquals.js
@@ -2,7 +2,11 @@
 import type Parcel from 'dataparcels';
 import shallowEquals from 'unmutable/lib/shallowEquals';
 
-export default (parcelA: Parcel, parcelB: Parcel): boolean => {
+export default (parcelA: ?Parcel, parcelB: ?Parcel): boolean => {
+    if(!parcelA || !parcelB) {
+        return false;
+    }
+
     let aa: Object = parcelA.data;
     let bb: Object = parcelB.data;
     let isChild: boolean = parcelA.isChild() && parcelB.isChild();

--- a/packages/react-dataparcels/src/util/__test__/ParcelBoundaryEquals-test.js
+++ b/packages/react-dataparcels/src/util/__test__/ParcelBoundaryEquals-test.js
@@ -52,3 +52,14 @@ test('ParcelBoundaryEquals should return false if isFirst or isLast change', () 
     // #a should be false as it used to be first but now isnt (value and meta are the same)
     expect(ParcelBoundaryEquals(p.get("#a"), p2.get("#a"))).toBe(false);
 });
+
+test('ParcelBoundaryEquals should return false if either argument is undefined', () => {
+    var child = {};
+
+    let p = new Parcel({
+        value: [123,456]
+    });
+
+    expect(ParcelBoundaryEquals(p, undefined)).toBe(false);
+    expect(ParcelBoundaryEquals(undefined, p)).toBe(false);
+});


### PR DESCRIPTION
## react-dataparcels

- Add `buffered` boolean to ParcelBoundary childRenderer arguments to indicate when there are buffered changes that havent been sent up yet
  - good for save buttons that only show when there are changes to save
- Add `${name}Buffered` boolean to ParcelBoundaryHoc child props
- **BREAKING CHANGE** `ParcelBoundary` and `ParcelBoundaryHoc` now use `getDerivedStateFromProps`. Use https://github.com/reactjs/react-lifecycles-compat if you're on a React version earlier than 16.3.0