### PR TITLE
Feature/snakey miscs

### DIFF
--- a/packages/dataparcels-docs/src/component/ApiPage.jsx
+++ b/packages/dataparcels-docs/src/component/ApiPage.jsx
@@ -68,10 +68,10 @@ export default ({name, api, md, after}: Props) => {
         nav={() => <Fragment>
             <NavigationList>
                 <NavigationListItem><Link to="/api">Api</Link></NavigationListItem>
-                <NavigationListItem>1. <Link to="/api/Parcel">Parcel</Link></NavigationListItem>
-                <NavigationListItem>2. <Link to="/api/ParcelHoc">ParcelHoc</Link></NavigationListItem>
-                <NavigationListItem>3. <Link to="/api/ParcelBoundary">ParcelBoundary</Link></NavigationListItem>
-                <NavigationListItem>4. <Link to="/api/ParcelBoundaryHoc">ParcelBoundaryHoc</Link></NavigationListItem>
+                <NavigationListItem>- <Link to="/api/Parcel">Parcel</Link></NavigationListItem>
+                <NavigationListItem>- <Link to="/api/ParcelHoc">ParcelHoc</Link></NavigationListItem>
+                <NavigationListItem>- <Link to="/api/ParcelBoundary">ParcelBoundary</Link></NavigationListItem>
+                <NavigationListItem>- <Link to="/api/ParcelBoundaryHoc">ParcelBoundaryHoc</Link></NavigationListItem>
             </NavigationList>
             <NavigationList>
                 <NavigationListItem>{name}</NavigationListItem>

--- a/packages/dataparcels-docs/src/docs/api/changeRequest/ChangeRequest.md
+++ b/packages/dataparcels-docs/src/docs/api/changeRequest/ChangeRequest.md
@@ -11,4 +11,6 @@ new ChangeRequest({
 });
 ```
 
-ChangeRequests are used by `dataparcels` to communicate changes back to the top level Parcel. Most of the time these operate invisibly.
+When a change occurs, ChangeRequests are used by Parcels to describe what to change and how to change it. These ChangeRequests are propagated upward to the top level Parcel.
+
+ChangeRequests can most often be accessed in `handleChange` and `modifyChange` functions. Most of the time these operate invisibly, and it's extremely rare that you'll create these yourself.

--- a/packages/dataparcels-docs/src/pages/api/ChangeRequest.jsx
+++ b/packages/dataparcels-docs/src/pages/api/ChangeRequest.jsx
@@ -10,9 +10,8 @@ const md = {
 
 const api = `
 # Properties
-value
-meta
-data
+prevData
+nextData
 changeRequestMeta
 originId
 originPath
@@ -22,8 +21,10 @@ setChangeRequestMeta()
 actions()
 updateActions()
 merge()
+getDataIn()
+hasValueChanged()
 toJS()
-
+toConsole()
 `;
 
 export default () => <ApiPage

--- a/packages/dataparcels-docs/src/pages/api/ChangeRequest.jsx
+++ b/packages/dataparcels-docs/src/pages/api/ChangeRequest.jsx
@@ -23,6 +23,7 @@ updateActions()
 merge()
 getDataIn()
 hasValueChanged()
+shouldBeSynchronous()
 toJS()
 toConsole()
 `;

--- a/packages/dataparcels-docs/src/pages/index.js
+++ b/packages/dataparcels-docs/src/pages/index.js
@@ -18,7 +18,7 @@ export default () => <Box>
                 bottom={() => <Grid>
                     <GridItem modifier="8 padding">
                         <Text element="p" modifier="monospace margin">A library for editing data structures that works really well with React.</Text>
-                        <Text element="p" modifier="monospace"><HtmlLink href="https://github.com/blueflag/dataparcels">github</HtmlLink> | <HtmlLink href="https://www.npmjs.com/package/react-dataparcels">npm</HtmlLink> | <HtmlLink href="#API">api</HtmlLink></Text>
+                        <Text element="p" modifier="monospace"><HtmlLink href="https://github.com/blueflag/dataparcels">github</HtmlLink> | <HtmlLink href="https://www.npmjs.com/package/react-dataparcels">npm</HtmlLink> | <HtmlLink href="#API">api documentation</HtmlLink></Text>
                     </GridItem>
                     <GridItem modifier="4 padding">
                         <Image modifier="center logo" src={IconParcel} />

--- a/packages/dataparcels/src/change/ActionCreators.js
+++ b/packages/dataparcels/src/change/ActionCreators.js
@@ -1,16 +1,8 @@
 // @flow
-import type {
-    Key,
-    Index
-} from '../types/Types';
-import Action from './Action';
+import type {Key} from '../types/Types';
+import type {Index} from '../types/Types';
 
-const del: Function = (key: Key|Index): Action => {
-    return new Action({
-        type: "delete",
-        keyPath: [key]
-    });
-};
+import Action from './Action';
 
 const deleteSelf: Function = (): Action => {
     return new Action({
@@ -156,7 +148,6 @@ const unshift: Function = (value: *): Action => {
 };
 
 export default {
-    delete: del,
     deleteSelf,
     insertAfter,
     insertAfterSelf,

--- a/packages/dataparcels/src/change/ChangeRequest.js
+++ b/packages/dataparcels/src/change/ChangeRequest.js
@@ -6,6 +6,7 @@ import type {ParcelData} from '../types/Types';
 import type Action from './Action';
 
 import {ReadOnlyError} from '../errors/Errors';
+import {ChangeRequestUnbasedError} from '../errors/Errors';
 import Reducer from '../change/Reducer';
 
 type ActionUpdater = (actions: Action[]) => Action[];
@@ -46,9 +47,9 @@ export default class ChangeRequest {
     };
 
     // $FlowFixMe - this doesn't have side effects
-    get data(): * {
+    get nextData(): * {
         if(!this._baseParcel) {
-            throw new Error(`ChangeRequest.data cannot be accessed before calling _setBaseParcel()`);
+            throw ChangeRequestUnbasedError();
         }
 
         if(this._cachedData) {
@@ -68,7 +69,7 @@ export default class ChangeRequest {
     }
 
     // $FlowFixMe - this doesn't have side effects
-    set data(value: *) {
+    set nextData(value: *) {
         throw ReadOnlyError();
     }
 

--- a/packages/dataparcels/src/change/ChangeRequest.js
+++ b/packages/dataparcels/src/change/ChangeRequest.js
@@ -8,6 +8,9 @@ import type Action from './Action';
 import {ReadOnlyError} from '../errors/Errors';
 import {ChangeRequestUnbasedError} from '../errors/Errors';
 import Reducer from '../change/Reducer';
+import parcelGet from '../parcelData/get';
+
+import pipe from 'unmutable/lib/util/pipe';
 
 type ActionUpdater = (actions: Action[]) => Action[];
 
@@ -140,6 +143,22 @@ export default class ChangeRequest {
     set originPath(value: *) {
         throw ReadOnlyError();
     }
+
+    getDataIn = (keyPath: Array<Key|Index>): {next: *, prev: *} => {
+        let getIn = pipe(
+            ...keyPath.map(key => parcelGet(key))
+        );
+
+        return {
+            next: getIn(this.nextData),
+            prev: getIn(this.prevData)
+        };
+    };
+
+    hasValueChanged = (keyPath: Array<Key|Index> = []): boolean => {
+        let {next, prev} = this.getDataIn(keyPath);
+        return next.value !== prev.value;
+    };
 
     toJS = (): Object => {
         return {

--- a/packages/dataparcels/src/change/ChangeRequest.js
+++ b/packages/dataparcels/src/change/ChangeRequest.js
@@ -73,6 +73,19 @@ export default class ChangeRequest {
         throw ReadOnlyError();
     }
 
+    // $FlowFixMe - this doesn't have side effects
+    get prevData(): * {
+        if(!this._baseParcel) {
+            throw ChangeRequestUnbasedError();
+        }
+        return this._baseParcel.data;
+    }
+
+    // $FlowFixMe - this doesn't have side effects
+    set prevData(value: *) {
+        throw ReadOnlyError();
+    }
+
     actions = (): Action[] => {
         return this._actions;
     };

--- a/packages/dataparcels/src/change/ChangeRequest.js
+++ b/packages/dataparcels/src/change/ChangeRequest.js
@@ -160,6 +160,12 @@ export default class ChangeRequest {
         return next.value !== prev.value;
     };
 
+    shouldBeSynchronous = (): boolean => {
+        return this
+            ._actions
+            .some(action => action.shouldBeSynchronous());
+    };
+
     toJS = (): Object => {
         return {
             actions: this._actions.map(action => action.toJS()),

--- a/packages/dataparcels/src/change/ChangeRequest.js
+++ b/packages/dataparcels/src/change/ChangeRequest.js
@@ -72,26 +72,6 @@ export default class ChangeRequest {
         throw ReadOnlyError();
     }
 
-    // $FlowFixMe - this doesn't have side effects
-    get value(): * {
-        return this.data.value;
-    }
-
-    // $FlowFixMe - this doesn't have side effects
-    set value(value: *) {
-        throw ReadOnlyError();
-    }
-
-    // $FlowFixMe - this doesn't have side effects
-    get meta (): * {
-        return this.data.meta;
-    }
-
-    // $FlowFixMe - this doesn't have side effects
-    set meta(value: *) {
-        throw ReadOnlyError();
-    }
-
     actions = (): Action[] => {
         return this._actions;
     };

--- a/packages/dataparcels/src/change/__test__/ChangeRequest-test.js
+++ b/packages/dataparcels/src/change/__test__/ChangeRequest-test.js
@@ -104,7 +104,7 @@ test('ChangeRequest _setBaseParcel() and data should use Reducer', () => {
 
     let {value} = new ChangeRequest(action)
         ._setBaseParcel(parcel)
-        .data;
+        .nextData;
 
     var expectedValue = {
         a: 1,
@@ -133,7 +133,7 @@ test('ChangeRequest data should get latest parcel data from treeshare when calle
             b: 2
         },
         handleChange: (parcel) => {
-            let {value} = ref.changeRequest.data;
+            let {value} = ref.changeRequest.nextData;
 
             var expectedValue = {
                 a: 4,
@@ -150,7 +150,7 @@ test('ChangeRequest data should get latest parcel data from treeshare when calle
 
 
 test('ChangeRequest should throw error if data is accessed before _setBaseParcel()', () => {
-    expect(() => new ChangeRequest().data).toThrowError(`ChangeRequest.data cannot be accessed before calling _setBaseParcel()`);
+    expect(() => new ChangeRequest().nextData).toThrowError(`ChangeRequest data cannot be accessed before calling changeRequest._setBaseParcel()`);
 });
 
 test('ChangeRequest should keep originId and originPath', () => {
@@ -226,7 +226,7 @@ test('ChangeRequest should cache its data after its calculated, so subsequent ca
     let data;
 
     let ms = TestTimeExecution(() => {
-        data = changeRequest.data;
+        data = changeRequest.nextData;
     });
 
     var expectedData = {
@@ -273,7 +273,7 @@ test('ChangeRequest should cache its data after its calculated, so subsequent ca
     expect(expectedData).toEqual(data);
 
     let ms2 = TestTimeExecution(() => {
-        data = changeRequest.data;
+        data = changeRequest.nextData;
     });
 
     expect(expectedData).toEqual(data);
@@ -295,20 +295,20 @@ test('ChangeRequest data chache should be invalidated correctly', () => {
     parcel
         .get('a')
         .modifyChangeBatch((parcel, changeRequest) => {
-            expect(changeRequest.data).toEqual({key: 'a', meta: {abc: 123}, value: {b: 456}, child: {b:{key: "b"}}});
-            expect(changeRequest.data).toEqual({key: 'a', meta: {abc: 123}, value: {b: 456}, child: {b:{key: "b"}}}); // get cached
+            expect(changeRequest.nextData).toEqual({key: 'a', meta: {abc: 123}, value: {b: 456}, child: {b:{key: "b"}}});
+            expect(changeRequest.nextData).toEqual({key: 'a', meta: {abc: 123}, value: {b: 456}, child: {b:{key: "b"}}}); // get cached
             parcel.dispatch(changeRequest);
         })
         .modifyChangeBatch((parcel, changeRequest) => {
-            expect(changeRequest.data).toEqual({key: 'a', meta: {}, value: {b: 456}, child: {b:{key: "b"}}});
-            expect(changeRequest.data).toEqual({key: 'a', meta: {}, value: {b: 456}, child: {b:{key: "b"}}}); // get cached
+            expect(changeRequest.nextData).toEqual({key: 'a', meta: {}, value: {b: 456}, child: {b:{key: "b"}}});
+            expect(changeRequest.nextData).toEqual({key: 'a', meta: {}, value: {b: 456}, child: {b:{key: "b"}}}); // get cached
             parcel.dispatch(changeRequest);
             parcel.setMeta({abc: 123});
         })
         .get('b')
         .modifyChangeBatch((parcel, changeRequest) => {
-            expect(changeRequest.data).toEqual({key: 'b', meta: {}, value: 456});
-            expect(changeRequest.data).toEqual({key: 'b', meta: {}, value: 456}); // get cached
+            expect(changeRequest.nextData).toEqual({key: 'b', meta: {}, value: 456});
+            expect(changeRequest.nextData).toEqual({key: 'b', meta: {}, value: 456}); // get cached
             parcel.dispatch(changeRequest);
         })
         .onChange(456);

--- a/packages/dataparcels/src/change/__test__/ChangeRequest-test.js
+++ b/packages/dataparcels/src/change/__test__/ChangeRequest-test.js
@@ -153,56 +153,6 @@ test('ChangeRequest should throw error if data is accessed before _setBaseParcel
     expect(() => new ChangeRequest().data).toThrowError(`ChangeRequest.data cannot be accessed before calling _setBaseParcel()`);
 });
 
-test('ChangeRequest value() should be a shortcut for data().value', () => {
-    var action = new Action({
-        type: "set",
-        keyPath: ["b"],
-        payload: {
-            value: 3
-        }
-    });
-
-    var parcel = new Parcel({
-        value: {
-            a: 1,
-            b: 2
-        }
-    });
-
-    let value = new ChangeRequest(action)
-        ._setBaseParcel(parcel)
-        .value;
-
-    var expectedValue = {
-        a: 1,
-        b: 3
-    };
-
-    expect(expectedValue).toEqual(value);
-});
-
-test('ChangeRequest .meta should be a shortcut for data().meta', () => {
-    var action = new Action({
-        type: "setMeta",
-        payload: {
-            meta: {
-                abc: 123
-            }
-        }
-    });
-
-    var parcel = new Parcel();
-
-    let {meta} = new ChangeRequest(action)
-        ._setBaseParcel(parcel);
-
-    var expectedMeta = {
-        abc: 123
-    };
-
-    expect(expectedMeta).toEqual(meta);
-});
-
 test('ChangeRequest should keep originId and originPath', () => {
     expect.assertions(2);
 

--- a/packages/dataparcels/src/change/__test__/ChangeRequest-test.js
+++ b/packages/dataparcels/src/change/__test__/ChangeRequest-test.js
@@ -114,6 +114,34 @@ test('ChangeRequest _setBaseParcel() and data should use Reducer', () => {
     expect(expectedValue).toEqual(value);
 });
 
+test('ChangeRequest prevData should return previous data', () => {
+    var action = new Action({
+        type: "set",
+        keyPath: ["b"],
+        payload: {
+            value: 3
+        }
+    });
+
+    var parcel = new Parcel({
+        value: {
+            a: 1,
+            b: 2
+        }
+    });
+
+    let {value} = new ChangeRequest(action)
+        ._setBaseParcel(parcel)
+        .prevData;
+
+    var expectedValue = {
+        a: 1,
+        b: 2
+    };
+
+    expect(expectedValue).toEqual(value);
+});
+
 test('ChangeRequest data should get latest parcel data from treeshare when called to prevent basing onto stale data', () => {
     expect.assertions(1);
 
@@ -151,6 +179,7 @@ test('ChangeRequest data should get latest parcel data from treeshare when calle
 
 test('ChangeRequest should throw error if data is accessed before _setBaseParcel()', () => {
     expect(() => new ChangeRequest().nextData).toThrowError(`ChangeRequest data cannot be accessed before calling changeRequest._setBaseParcel()`);
+    expect(() => new ChangeRequest().prevData).toThrowError(`ChangeRequest data cannot be accessed before calling changeRequest._setBaseParcel()`);
 });
 
 test('ChangeRequest should keep originId and originPath', () => {

--- a/packages/dataparcels/src/change/__test__/ChangeRequest-test.js
+++ b/packages/dataparcels/src/change/__test__/ChangeRequest-test.js
@@ -342,3 +342,104 @@ test('ChangeRequest data chache should be invalidated correctly', () => {
         })
         .onChange(456);
 });
+
+test('ChangeRequest getDataIn should return previous and next value at keyPath', () => {
+    var action = new Action({
+        type: "set",
+        keyPath: ["a", "c", "#a"],
+        payload: {
+            value: 100
+        }
+    });
+
+    var parcel = new Parcel({
+        value: {
+            a: {
+                c: [0,1],
+                d: 2
+            },
+            b: 3
+        }
+    });
+
+    let basedChangeRequest = new ChangeRequest(action)._setBaseParcel(parcel);
+    let {next, prev} = basedChangeRequest.getDataIn(['a', 'c', '#a']);
+
+    expect(next.value).toBe(100);
+    expect(prev.value).toBe(0);
+});
+
+test('ChangeRequest hasValueChanged should indicate if value changed at path', () => {
+    var action = new Action({
+        type: "set",
+        keyPath: ["a", "c", "#a"],
+        payload: {
+            value: 100
+        }
+    });
+
+    var parcel = new Parcel({
+        value: {
+            a: {
+                c: [0,1],
+                d: 2
+            },
+            b: 3
+        }
+    });
+
+    let basedChangeRequest = new ChangeRequest(action)._setBaseParcel(parcel);
+
+    expect(basedChangeRequest.hasValueChanged(['a', 'c', '#a'])).toBe(true);
+    expect(basedChangeRequest.hasValueChanged(['a', 'c', '#b'])).toBe(false);
+    expect(basedChangeRequest.hasValueChanged(['a', 'c'])).toBe(true);
+    expect(basedChangeRequest.hasValueChanged(['a', 'd'])).toBe(false);
+    expect(basedChangeRequest.hasValueChanged(['a'])).toBe(true);
+    expect(basedChangeRequest.hasValueChanged(['b'])).toBe(false);
+    expect(basedChangeRequest.hasValueChanged()).toBe(true);
+});
+
+test('ChangeRequest hasValueChanged should indicate if value changed at path due to deletion', () => {
+    var action = new Action({
+        type: "delete",
+        keyPath: ["a"]
+    });
+
+    var parcel = new Parcel({
+        value: {
+            a: {
+                b: 100
+            },
+            b: 2
+        }
+    });
+
+    let basedChangeRequest = new ChangeRequest(action)._setBaseParcel(parcel);
+
+    expect(basedChangeRequest.hasValueChanged(['a'])).toBe(true);
+    expect(basedChangeRequest.hasValueChanged(['a', 'b'])).toBe(true);
+    expect(basedChangeRequest.hasValueChanged(['b'])).toBe(false);
+});
+
+test('ChangeRequest hasValueChanged should indicate if value changed in array, identifying elements by key', () => {
+    var action = new Action({
+        type: "insertBefore",
+        keyPath: ["#b"],
+        payload: {
+            value: 999
+        }
+    });
+
+    var parcel = new Parcel({
+        value: [0,1,2,3]
+    });
+
+    let basedChangeRequest = new ChangeRequest(action)._setBaseParcel(parcel);
+
+    expect(basedChangeRequest.hasValueChanged(['#a'])).toBe(false);
+    expect(basedChangeRequest.hasValueChanged(['#b'])).toBe(false);
+    expect(basedChangeRequest.hasValueChanged(['#c'])).toBe(false);
+    expect(basedChangeRequest.hasValueChanged(['#d'])).toBe(false);
+    expect(basedChangeRequest.hasValueChanged(['#e'])).toBe(true);
+    expect(basedChangeRequest.hasValueChanged()).toBe(true);
+});

--- a/packages/dataparcels/src/errors/Errors.js
+++ b/packages/dataparcels/src/errors/Errors.js
@@ -5,3 +5,4 @@ export const ReducerInvalidActionError = (actionType: string) => new Error(`"${a
 export const ReducerSwapKeyError = () =>  new Error(`swap actions must have a swapKey in their payload`);
 export const ModifyValueChildReturnError = () =>  new Error(`.modifyValue()'s updater can not return a value that has children unless it is unchanged by the updater or is empty.`);
 export const ModifyValueChangeChildReturnError = () =>  new Error(`When .modifyChangeValue()'s updater is passed a value that has children, it cannot return a value that has children unless it is unchanged by the updater`);
+export const ChangeRequestUnbasedError = () =>  new Error(`ChangeRequest data cannot be accessed before calling changeRequest._setBaseParcel()`);

--- a/packages/dataparcels/src/parcel/__test__/IndexedParcelMethods-test.js
+++ b/packages/dataparcels/src/parcel/__test__/IndexedParcelMethods-test.js
@@ -2,7 +2,6 @@
 import Parcel from '../Parcel';
 
 test('IndexedParcel.delete() should delete', () => {
-    expect.assertions(4);
 
     var data = {
         value: [1,2,3],
@@ -25,31 +24,27 @@ test('IndexedParcel.delete() should delete', () => {
 
     var expectedAction = {
         type: "delete",
-        keyPath: [0],
-        payload: {}
-    };
-
-    var expectedActionWithKey = {
-        type: "delete",
         keyPath: ["#a"],
         payload: {}
     };
 
+    var indexedHandleChange = jest.fn();
+    var keyedHandleChange = jest.fn();
+
     new Parcel({
         ...data,
-        handleChange: (parcel, changeRequest) => {
-            expect(expectedData).toEqual(parcel.data);
-            expect(expectedAction).toEqual(changeRequest.actions()[0].toJS());
-        }
+        handleChange: indexedHandleChange
     }).delete(0);
 
     new Parcel({
         ...data,
-        handleChange: (parcel, changeRequest) => {
-            expect(expectedData).toEqual(parcel.data);
-            expect(expectedActionWithKey).toEqual(changeRequest.actions()[0].toJS());
-        }
+        handleChange: keyedHandleChange
     }).delete("#a");
+
+    expect(indexedHandleChange.mock.calls[0][0].data).toEqual(expectedData);
+    expect(indexedHandleChange.mock.calls[0][1].actions()[0].toJS()).toEqual(expectedAction);
+    expect(keyedHandleChange.mock.calls[0][0].data).toEqual(expectedData);
+    expect(keyedHandleChange.mock.calls[0][1].actions()[0].toJS()).toEqual(expectedAction);
 
 });
 
@@ -77,7 +72,6 @@ test('IndexedParcel.get(hashkey) should return a new child Parcel', () => {
 });
 
 test('IndexedParcel.insertBefore() should insertBefore', () => {
-    expect.assertions(4);
 
     var data = {
         value: [1,2,3],
@@ -116,25 +110,27 @@ test('IndexedParcel.insertBefore() should insertBefore', () => {
         }
     };
 
+    var indexedHandleChange = jest.fn();
+    var keyedHandleChange = jest.fn();
+
     new Parcel({
         ...data,
-        handleChange: (parcel, changeRequest) => {
-            expect(expectedData).toEqual(parcel.data);
-            expect(expectedAction).toEqual(changeRequest.actions()[0].toJS());
-        }
+        handleChange: indexedHandleChange
     }).insertBefore(1, 4);
 
     new Parcel({
         ...data,
-        handleChange: (parcel, changeRequest) => {
-            expect(expectedData).toEqual(parcel.data);
-            expect(expectedActionWithKey).toEqual(changeRequest.actions()[0].toJS());
-        }
+        handleChange: keyedHandleChange
     }).insertBefore("#b", 4);
+
+    expect(indexedHandleChange.mock.calls[0][0].data).toEqual(expectedData);
+    expect(indexedHandleChange.mock.calls[0][1].actions()[0].toJS()).toEqual(expectedAction);
+    expect(keyedHandleChange.mock.calls[0][0].data).toEqual(expectedData);
+    expect(keyedHandleChange.mock.calls[0][1].actions()[0].toJS()).toEqual(expectedActionWithKey);
+
 });
 
 test('IndexedParcel.insertAfter() should insertAfter', () => {
-    expect.assertions(4);
 
     var data = {
         value: [1,2,3],
@@ -173,21 +169,23 @@ test('IndexedParcel.insertAfter() should insertAfter', () => {
         }
     };
 
+    var indexedHandleChange = jest.fn();
+    var keyedHandleChange = jest.fn();
+
     new Parcel({
         ...data,
-        handleChange: (parcel, changeRequest) => {
-            expect(expectedData).toEqual(parcel.data);
-            expect(expectedAction).toEqual(changeRequest.actions()[0].toJS());
-        }
+        handleChange: indexedHandleChange
     }).insertAfter(1, 4);
 
     new Parcel({
         ...data,
-        handleChange: (parcel, changeRequest) => {
-            expect(expectedData).toEqual(parcel.data);
-            expect(expectedActionWithKey).toEqual(changeRequest.actions()[0].toJS());
-        }
+        handleChange: keyedHandleChange
     }).insertAfter("#b", 4);
+
+    expect(indexedHandleChange.mock.calls[0][0].data).toEqual(expectedData);
+    expect(indexedHandleChange.mock.calls[0][1].actions()[0].toJS()).toEqual(expectedAction);
+    expect(keyedHandleChange.mock.calls[0][0].data).toEqual(expectedData);
+    expect(keyedHandleChange.mock.calls[0][1].actions()[0].toJS()).toEqual(expectedActionWithKey);
 });
 
 test('IndexedParcel.push() should push', () => {

--- a/packages/dataparcels/src/parcel/__test__/ModifyMethods-test.js
+++ b/packages/dataparcels/src/parcel/__test__/ModifyMethods-test.js
@@ -109,7 +109,7 @@ test('Parcel.modifyChangeBatch() should allow you to change the payload of a cha
 
     new Parcel(data)
         .modifyChangeBatch((parcel: Parcel, changeRequest: ChangeRequest) => {
-            parcel.set(changeRequest.data.value + 1);
+            parcel.set(changeRequest.nextData.value + 1);
         })
         .onChange(456);
 });

--- a/packages/dataparcels/src/parcel/__test__/ParcelChangeMethods-test.js
+++ b/packages/dataparcels/src/parcel/__test__/ParcelChangeMethods-test.js
@@ -27,7 +27,7 @@ test('Parcel.set() should call the Parcels handleChange function with the new pa
         ...data,
         handleChange: (parcel, changeRequest) => {
             expect(expectedData).toEqual(parcel.data);
-            expect(expectedData).toEqual(changeRequest.data);
+            expect(expectedData).toEqual(changeRequest.nextData);
             expect(expectedAction).toEqual(changeRequest.actions()[0].toJS());
         }
     }).set(456);

--- a/packages/dataparcels/src/parcel/__test__/ParcelGetMethods-test.js
+++ b/packages/dataparcels/src/parcel/__test__/ParcelGetMethods-test.js
@@ -122,8 +122,8 @@ test('Parcel.spyChange() should be called with changeRequest', () => {
         .spyChange(spy2)
         .onChange(456);
 
-    expect(spy2.mock.calls[0][0].data.value).toEqual(456);
-    expect(spy.mock.calls[0][0].data.value).toEqual({abc: 456});
+    expect(spy2.mock.calls[0][0].nextData.value).toEqual(456);
+    expect(spy.mock.calls[0][0].nextData.value).toEqual({abc: 456});
 });
 
 test('Parcel.pipe() should pass itself in and return what pipe() returns', () => {

--- a/packages/dataparcels/src/parcel/__test__/ParcelGetMethods-test.js
+++ b/packages/dataparcels/src/parcel/__test__/ParcelGetMethods-test.js
@@ -122,8 +122,8 @@ test('Parcel.spyChange() should be called with changeRequest', () => {
         .spyChange(spy2)
         .onChange(456);
 
-    expect(spy2.mock.calls[0][0].value).toEqual(456);
-    expect(spy.mock.calls[0][0].value).toEqual({abc: 456});
+    expect(spy2.mock.calls[0][0].data.value).toEqual(456);
+    expect(spy.mock.calls[0][0].data.value).toEqual({abc: 456});
 });
 
 test('Parcel.pipe() should pass itself in and return what pipe() returns', () => {

--- a/packages/dataparcels/src/parcel/__test__/ParentChangeMethods-test.js
+++ b/packages/dataparcels/src/parcel/__test__/ParentChangeMethods-test.js
@@ -37,6 +37,24 @@ test('ParentParcel.update(key) should call the Parcels handleChange function wit
     });
 });
 
+test('ParentParcel.delete(key) should delete', () => {
+    var handleChange = jest.fn();
+
+    new Parcel({
+        value: {
+            abc: 123,
+            def: 456
+        },
+        handleChange
+    }).delete("abc");
+
+    var expectedValue = {
+        def: 456
+    };
+
+    expect(handleChange.mock.calls[0][0].value).toEqual(expectedValue);
+});
+
 test('ParentParcel.setIn(keyPath) should call the Parcels handleChange function with the new parcelData', () => {
     expect.assertions(1);
 

--- a/packages/dataparcels/src/parcel/methods/ActionMethods.js
+++ b/packages/dataparcels/src/parcel/methods/ActionMethods.js
@@ -42,7 +42,7 @@ export default (_this: Parcel): Object => ({
         if(_onHandleChange) {
             let changeRequestWithBase = changeRequest._setBaseParcel(_this);
             let parcelWithChangedData = _this._create({
-                parcelData: changeRequestWithBase.data
+                parcelData: changeRequestWithBase.nextData
             });
 
             _onHandleChange(parcelWithChangedData, changeRequestWithBase);
@@ -65,7 +65,7 @@ export default (_this: Parcel): Object => ({
             buffer = buffer.merge(changeRequest);
             _this._parcelData = changeRequest
                 ._setBaseParcel(_this)
-                .data;
+                .nextData;
         };
 
         batcher(_this);

--- a/packages/dataparcels/src/parcel/methods/IndexedChangeMethods.js
+++ b/packages/dataparcels/src/parcel/methods/IndexedChangeMethods.js
@@ -8,11 +8,6 @@ import ActionCreators from '../../change/ActionCreators';
 
 export default (_this: Parcel, dispatch: Function): Object => ({
 
-    delete: (key: Key|Index) => {
-        Types(`delete()`, `key`, `keyIndex`)(key);
-        dispatch(ActionCreators.delete(key));
-    },
-
     insertAfter: (key: Key|Index, value: *) => {
         Types(`insertAfter()`, `key`, `keyIndex`)(key);
         dispatch(ActionCreators.insertAfter(key, value));

--- a/packages/dataparcels/src/parcel/methods/ModifyMethods.js
+++ b/packages/dataparcels/src/parcel/methods/ModifyMethods.js
@@ -77,7 +77,7 @@ export default (_this: Parcel): Object => ({
         Types(`modifyChangeValue()`, `updater`, `function`)(updater);
         return _this.modifyChangeBatch((parcel: Parcel, changeRequest: ChangeRequest) => {
 
-            let {value} = changeRequest;
+            let {value} = changeRequest.data;
             let type = new ParcelTypes(value);
 
             let updatedValue = updater(value, _this);

--- a/packages/dataparcels/src/parcel/methods/ModifyMethods.js
+++ b/packages/dataparcels/src/parcel/methods/ModifyMethods.js
@@ -77,7 +77,7 @@ export default (_this: Parcel): Object => ({
         Types(`modifyChangeValue()`, `updater`, `function`)(updater);
         return _this.modifyChangeBatch((parcel: Parcel, changeRequest: ChangeRequest) => {
 
-            let {value} = changeRequest.data;
+            let {value} = changeRequest.nextData;
             let type = new ParcelTypes(value);
 
             let updatedValue = updater(value, _this);

--- a/packages/dataparcels/src/parcel/methods/ParentChangeMethods.js
+++ b/packages/dataparcels/src/parcel/methods/ParentChangeMethods.js
@@ -17,6 +17,11 @@ export default (_this: Parcel /*, dispatch: Function*/): Object => ({
         _this.get(key).update(updater);
     },
 
+    delete: (key: Key|Index) => {
+        Types(`delete()`, `key`, `keyIndex`)(key);
+        _this.get(key).delete();
+    },
+
     setIn: (keyPath: Array<Key|Index>, value: *) => {
         Types(`setIn()`, `keyPath`, `keyIndexPath`)(keyPath);
         _this.getIn(keyPath).set(value);

--- a/packages/react-dataparcels/src/ParcelBoundary.jsx
+++ b/packages/react-dataparcels/src/ParcelBoundary.jsx
@@ -210,9 +210,7 @@ export default class ParcelBoundary extends React.Component<Props, State> { /* e
                     newParcel.toConsole();
                 }
 
-                let shouldBeSynchronous = () => changeRequest
-                    .actions()
-                    .some(action => action.shouldBeSynchronous());
+                let shouldBeSynchronous = () => changeRequest.shouldBeSynchronous();
 
                 let updateParcel = set('parcel', newParcel);
                 let addToBuffer = this.addToBuffer(changeRequest);


### PR DESCRIPTION
## dataparcels

- Fix: `Parcel.delete(key)` should be able to be used on non-indexed parent parcels #138 
- Add: `ChangeRequest.prevData` #138 
- **BREAKING CHANGE** Renamed `ChangeRequest.data` to `ChangeRequest.nextData` #138 
- **BREAKING CHANGE** Removed `ChangeRequest.value` and `ChangeRequest.meta` #138 
  - Use `ChangeRequest.nextData.value` and `ChangeRequest.nextData.meta` instead
- Add: `ChangeRequest.hasValueChanged()` #134 
- Add: `ChangeRequest.shouldBeSynchronous()`
- Add: `ChangeRequest.getDataIn()`
