### PR TITLE
add: ability for push and unshift to accept multiple args

### DIFF
--- a/packages/dataparcels-docs/src/docs/api/parcel/push.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/push.md
@@ -1,3 +1,3 @@
 ```flow
-push(value: *): void // only on IndexedParcels
+push(...values: Array<*>): void // only on IndexedParcels
 ```

--- a/packages/dataparcels-docs/src/docs/api/parcel/unshift.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/unshift.md
@@ -1,3 +1,3 @@
 ```flow
-unshift(value: *): void // only on IndexedParcels
+unshift(...values: Array<*>): void // only on IndexedParcels
 ```

--- a/packages/dataparcels-docs/src/docs/api/staticParcel/push.md
+++ b/packages/dataparcels-docs/src/docs/api/staticParcel/push.md
@@ -1,3 +1,3 @@
 ```flow
-push(value: *): void // only on IndexedParcels
+push(...values: Array<*>): void // only on IndexedParcels
 ```

--- a/packages/dataparcels-docs/src/docs/api/staticParcel/unshift.md
+++ b/packages/dataparcels-docs/src/docs/api/staticParcel/unshift.md
@@ -1,3 +1,3 @@
 ```flow
-unshift(value: *): void // only on IndexedParcels
+unshift(...values: Array<*>): void // only on IndexedParcels
 ```

--- a/packages/dataparcels/src/change/ActionCreators.js
+++ b/packages/dataparcels/src/change/ActionCreators.js
@@ -49,11 +49,11 @@ const insertBeforeSelf: Function = (value: *): Action => {
     });
 };
 
-const push: Function = (value: *): Action => {
+const push: Function = (values: Array<*>): Action => {
     return new Action({
         type: "push",
         payload: {
-            value
+            values
         }
     });
 };
@@ -140,11 +140,11 @@ const swapSelf: Function = (keyB: Key|Index): Action => {
     });
 };
 
-const unshift: Function = (value: *): Action => {
+const unshift: Function = (values: Array<*>): Action => {
     return new Action({
         type: "unshift",
         payload: {
-            value
+            values
         }
     });
 };

--- a/packages/dataparcels/src/change/ChangeRequestReducer.js
+++ b/packages/dataparcels/src/change/ChangeRequestReducer.js
@@ -32,12 +32,12 @@ const actionMap = {
     insertAfter: ({lastKey, value}) => insertAfter(lastKey, value),
     insertBefore: ({lastKey, value}) => insertBefore(lastKey, value),
     pop: () => pop(),
-    push: ({value}) => push(value),
+    push: ({values}) => push(...values),
     setData: parcelData => () => parcelData,
     setMeta: ({meta}) => setMeta(meta),
     set: ({value}) => setSelf(value),
     shift: () => shift(),
-    swap: ({lastKey, swapKey}) => {
+    swap: ({lastKey, swapKey}: any): ParcelDataEvaluator => {
         if(typeof swapKey === "undefined") {
             throw ReducerSwapKeyError();
         }
@@ -45,7 +45,7 @@ const actionMap = {
     },
     swapNext: ({lastKey}) => swapNext(lastKey),
     swapPrev: ({lastKey}) => swapPrev(lastKey),
-    unshift: ({value}) => unshift(value)
+    unshift: ({values}) => unshift(...values)
 };
 
 const parentActionMap = {

--- a/packages/dataparcels/src/change/__test__/ChangeRequestReducerIndexed-test.js
+++ b/packages/dataparcels/src/change/__test__/ChangeRequestReducerIndexed-test.js
@@ -259,12 +259,12 @@ TestIndex([
             type: "push",
             keyPath: [],
             payload: {
-                value: 3
+                values: [3,4]
             }
         },
         expectedData: {
-            value: [0,1,2,3],
-            child: [{key: "#a"},{key: "#b"}, {key: "#c"},{key: "#d"}],
+            value: [0,1,2,3,4],
+            child: [{key: "#a"},{key: "#b"}, {key: "#c"},{key: "#d"},{key: "#e"}],
             ...EXPECTED_KEY_AND_META
         }
     }
@@ -430,12 +430,12 @@ TestIndex([
             type: "unshift",
             keyPath: [],
             payload: {
-                value: 3
+                values: [3,4]
             }
         },
         expectedData: {
-            value: [3,0,1,2],
-            child: [{key: "#d"},{key: "#a"},{key: "#b"}, {key: "#c"}],
+            value: [3,4,0,1,2],
+            child: [{key: "#d"},{key: "#e"},{key: "#a"},{key: "#b"}, {key: "#c"}],
             ...EXPECTED_KEY_AND_META
         }
     }

--- a/packages/dataparcels/src/parcel/Parcel.js
+++ b/packages/dataparcels/src/parcel/Parcel.js
@@ -315,7 +315,7 @@ export default class Parcel {
         ["1"]: (value: any) => this._methods.insertBeforeSelf(value),
         ["2"]: (key: Key|Index, value: any) => this._methods.insertBefore(key, value)
     });
-    push = (value: any) => this._methods.push(value);
+    push = (...values: Array<any>) => this._methods.push(...values);
     pop = () => this._methods.pop();
     shift = () => this._methods.shift();
     swap = overload({
@@ -330,7 +330,7 @@ export default class Parcel {
         ["0"]: () => this._methods.swapPrevSelf(),
         ["1"]: (key: Key|Index) => this._methods.swapPrev(key)
     });
-    unshift = (value: any) => this._methods.unshift(value);
+    unshift = (...values: Array<any>) => this._methods.unshift(...values);
 
     // Modify methods
     modifyDown = (updater: Function): Parcel => this._methods.modifyDown(updater);

--- a/packages/dataparcels/src/parcel/__test__/IndexedParcelMethods-test.js
+++ b/packages/dataparcels/src/parcel/__test__/IndexedParcelMethods-test.js
@@ -204,13 +204,14 @@ test('IndexedParcel.push() should push', () => {
 
     var expectedData = {
         meta: {},
-        value: [1,2,3,4],
+        value: [1,2,3,4,5],
         key: '^',
         child: [
             {key: "#a"},
             {key: "#b"},
             {key: "#c"},
-            {key: "#d"}
+            {key: "#d"},
+            {key: "#e"}
         ]
     };
 
@@ -218,7 +219,7 @@ test('IndexedParcel.push() should push', () => {
         type: "push",
         keyPath: [],
         payload: {
-            value: 4
+            values: [4,5]
         }
     };
 
@@ -228,7 +229,7 @@ test('IndexedParcel.push() should push', () => {
             expect(expectedData).toEqual(parcel.data);
             expect(expectedAction).toEqual(GetAction(changeRequest));
         }
-    }).push(4);
+    }).push(4,5);
 });
 
 test('IndexedParcel.pop() should pop', () => {
@@ -464,10 +465,11 @@ test('IndexedParcel.unshift() should unshift', () => {
 
     var expectedData = {
         meta: {},
-        value: [4,1,2,3],
+        value: [4,5,1,2,3],
         key: '^',
         child: [
             {key: "#d"},
+            {key: "#e"},
             {key: "#a"},
             {key: "#b"},
             {key: "#c"}
@@ -478,7 +480,7 @@ test('IndexedParcel.unshift() should unshift', () => {
         type: "unshift",
         keyPath: [],
         payload: {
-            value: 4
+            values: [4,5]
         }
     };
 
@@ -488,5 +490,5 @@ test('IndexedParcel.unshift() should unshift', () => {
             expect(expectedData).toEqual(parcel.data);
             expect(expectedAction).toEqual(GetAction(changeRequest));
         }
-    }).unshift(4);
+    }).unshift(4,5);
 });

--- a/packages/dataparcels/src/parcel/methods/IndexedChangeMethods.js
+++ b/packages/dataparcels/src/parcel/methods/IndexedChangeMethods.js
@@ -18,8 +18,8 @@ export default (_this: Parcel, dispatch: Function): Object => ({
         dispatch(ActionCreators.insertBefore(key, value));
     },
 
-    push: (value: *) => {
-        dispatch(ActionCreators.push(value));
+    push: (...values: Array<*>) => {
+        dispatch(ActionCreators.push(values));
     },
 
     pop: () => {
@@ -46,7 +46,7 @@ export default (_this: Parcel, dispatch: Function): Object => ({
         dispatch(ActionCreators.swapPrev(key));
     },
 
-    unshift: (value: *) => {
-        dispatch(ActionCreators.unshift(value));
+    unshift: (...values: Array<*>) => {
+        dispatch(ActionCreators.unshift(values));
     }
 });

--- a/packages/dataparcels/src/parcelData/push.js
+++ b/packages/dataparcels/src/parcelData/push.js
@@ -5,11 +5,13 @@ import updateChildKeys from './updateChildKeys';
 
 import push from 'unmutable/lib/push';
 
-export default (newValue: *) => (parcelData: ParcelData): ParcelData => {
+export default (...newValues: Array<*>) => (parcelData: ParcelData): ParcelData => {
     let {value, child, ...rest} = prepareChildKeys()(parcelData);
+    let emptyChildren = newValues.map(() => ({}));
+
     return updateChildKeys()({
         ...rest,
-        value: push(newValue)(value),
-        child: push({})(child)
+        value: push(...newValues)(value),
+        child: push(...emptyChildren)(child)
     });
 };

--- a/packages/dataparcels/src/parcelData/unshift.js
+++ b/packages/dataparcels/src/parcelData/unshift.js
@@ -5,11 +5,13 @@ import updateChildKeys from './updateChildKeys';
 
 import unshift from 'unmutable/lib/unshift';
 
-export default (newValue: *) => (parcelData: ParcelData): ParcelData => {
+export default (...newValues: Array<*>) => (parcelData: ParcelData): ParcelData => {
     let {value, child, ...rest} = prepareChildKeys()(parcelData);
+    let emptyChildren = newValues.map(() => ({}));
+
     return updateChildKeys()({
         ...rest,
-        value: unshift(newValue)(value),
-        child: unshift({})(child)
+        value: unshift(...newValues)(value),
+        child: unshift(...emptyChildren)(child)
     });
 };

--- a/packages/dataparcels/src/staticParcel/StaticParcel.js
+++ b/packages/dataparcels/src/staticParcel/StaticParcel.js
@@ -187,13 +187,13 @@ export default class StaticParcel {
     // Indexed methods
     insertAfter = (key: Key|Index, value: any) => this._methods.insertAfter(key, value);
     insertBefore = (key: Key|Index, value: any) => this._methods.insertBefore(key, value);
-    push = (value: any) => this._methods.push(value);
+    push = (...values: Array<any>) => this._methods.push(...values);
     pop = () => this._methods.pop();
     shift = () => this._methods.shift();
     swap = (keyA: Key|Index, keyB: Key|Index) => this._methods.swap(keyA, keyB);
     swapNext = (key: Key|Index) => this._methods.swapNext(key);
     swapPrev = (key: Key|Index) => this._methods.swapPrev(key);
-    unshift = (value: any) => this._methods.unshift(value);
+    unshift = (...values: Array<any>) => this._methods.unshift(...values);
 
     // Type methods
     isChild = (): boolean => this._parcelTypes.isChild();

--- a/packages/dataparcels/src/staticParcel/__test__/StaticIndexedSetMethods-test.js
+++ b/packages/dataparcels/src/staticParcel/__test__/StaticIndexedSetMethods-test.js
@@ -22,7 +22,7 @@ test('StaticParcels push(value) should work', () => {
         value: [0,1,2]
     });
 
-    expect(staticParcel.push(3).data.value).toEqual([0,1,2,3]);
+    expect(staticParcel.push(3,4).data.value).toEqual([0,1,2,3,4]);
 });
 
 test('StaticParcels pop() should work', () => {
@@ -70,5 +70,5 @@ test('StaticParcels unshift(value) should work', () => {
         value: [0,1,2]
     });
 
-    expect(staticParcel.unshift(3).data.value).toEqual([3,0,1,2]);
+    expect(staticParcel.unshift(3,4).data.value).toEqual([3,4,0,1,2]);
 });

--- a/packages/dataparcels/src/staticParcel/methods/StaticIndexedSetMethods.js
+++ b/packages/dataparcels/src/staticParcel/methods/StaticIndexedSetMethods.js
@@ -36,10 +36,10 @@ export default (_this: StaticParcel) => ({
         );
     },
 
-    push: (value: *): StaticParcel => {
+    push: (...values: Array<*>): StaticParcel => {
         _this._prepareChildKeys();
         return _this._pipeSelf(
-            push(value)
+            push(...values)
         );
     },
 
@@ -71,10 +71,10 @@ export default (_this: StaticParcel) => ({
         );
     },
 
-    unshift: (value: *): StaticParcel => {
+    unshift: (...values: Array<*>): StaticParcel => {
         _this._prepareChildKeys();
         return _this._pipeSelf(
-            unshift(value)
+            unshift(...values)
         );
     }
 });


### PR DESCRIPTION
## dataparcels

- add: ability for `Parcel.push()`, `Parcel.unshift()`, `StaticParcel.push()` and `StaticParcel.unshift()` to accept multiple arguments #163 
- No breaking changes

## react-dataparcels

- No change