### PR TITLE
fix: fix Parcel.initialMeta value passing

### DIFF
--- a/packages/dataparcels/src/parcel/Parcel.js
+++ b/packages/dataparcels/src/parcel/Parcel.js
@@ -338,7 +338,7 @@ export default class Parcel {
     modifyShapeDown = (updater: Function): Parcel => this._methods.modifyShapeDown(updater);
     modifyShapeUp = (updater: Function): Parcel => this._methods.modifyShapeUp(updater);
     modifyChange = (batcher: ParcelBatcher): Parcel => this._methods.modifyChange(batcher);
-    initialMeta = (initialMeta: ParcelMeta = {}): Parcel => this._methods.initialMeta(initialMeta);
+    initialMeta = (initialMeta: ParcelMeta): Parcel => this._methods.initialMeta(initialMeta);
     _boundarySplit = (config: *): Parcel => this._methods._boundarySplit(config);
 
     // Type methods

--- a/packages/dataparcels/src/parcel/__test__/ModifyMethods-test.js
+++ b/packages/dataparcels/src/parcel/__test__/ModifyMethods-test.js
@@ -307,24 +307,14 @@ test('Parcel.initialMeta() should merge', () => {
 });
 
 test('Parcel.initialMeta() should do nothing to data if all meta keys are already set', () => {
-    let handleChange = jest.fn();
 
     let parcel = new Parcel({
-        value: 123,
-        handleChange
-    })
-        .initialMeta({a:1, b:2})
-        .initialMeta({a:1, b:2}) // do nothing to data
+        value: 123
+    }).initialMeta({a:1, b:2});
 
-    expect(parcel.data).toEqual({
-        value: 123,
-        meta: {
-            a: 1,
-            b: 2
-        },
-        child: undefined,
-        key: "^"
-    });
+    let parcel2 = parcel.initialMeta({a:1, b:2});
+
+    expect(parcel2.data).toEqual(parcel.data);
 });
 
 test('Sanity check: A big strange test of a big strange chain of deep updatery stuff', () => {

--- a/packages/dataparcels/src/parcel/__test__/ModifyMethods-test.js
+++ b/packages/dataparcels/src/parcel/__test__/ModifyMethods-test.js
@@ -240,44 +240,52 @@ test('Parcel.modifyShapeUp() should modify value', () => {
 });
 
 test('Parcel.initialMeta() should work', () => {
-    expect.assertions(3);
+    let handleChange = jest.fn();
 
-    let meta = {a:1, b:2};
-
-    var data = {
+    let parcel = new Parcel({
         value: 123,
-        handleChange: (parcel: Parcel) => {
-            let {meta} = parcel.data;
-            expect({a:1, b:3}).toEqual(meta);
-            expect({a:1, b:3}).toEqual(parcel.initialMeta().meta);
-        }
-    };
+        handleChange
+    }).initialMeta({a:1, b:2});
 
-    let parcel = new Parcel(data).initialMeta(meta);
-    expect(meta).toEqual(parcel.meta);
-    parcel.setMeta({
-        b: 3
+    expect(parcel.meta).toEqual({a:1, b:2});
+
+    parcel.setMeta({b: 3});
+
+    expect(handleChange.mock.calls[0][0].data).toEqual({
+        value: 123,
+        meta: {
+            a: 1,
+            b: 3
+        },
+        child: undefined,
+        key: "^"
     });
 });
 
 test('Parcel.initialMeta() should merge', () => {
-    expect.assertions(2);
+    let handleChange = jest.fn();
 
-    let meta = {a:1, b:2};
-    let meta2 = {b:1, c:3}; // this b will be ignored because it will have already been set by the time this is applied
-
-    var data = {
+    let parcel = new Parcel({
         value: 123,
-        handleChange: (parcel: Parcel) => {
-            let {meta} = parcel.data;
-            expect({a:1, b:3, c:3}).toEqual(meta);
-        }
-    };
+        handleChange
+    })
+        .initialMeta({a:1, b:2})
+        .initialMeta({b:3, c:4})
 
-    let parcel = new Parcel(data).initialMeta(meta).initialMeta(meta2);
-    expect({a:1, b:2, c:3}).toEqual(parcel.meta);
-    parcel.setMeta({
-        b: 3
+    expect(parcel.meta).toEqual({a:1, b:2, c:4});
+
+    parcel.setMeta({d: 5});
+
+    expect(handleChange.mock.calls[0][0].data).toEqual({
+        value: 123,
+        meta: {
+            a: 1,
+            b: 2,
+            c: 4,
+            d: 5
+        },
+        child: undefined,
+        key: "^"
     });
 });
 

--- a/packages/dataparcels/src/parcel/__test__/ModifyMethods-test.js
+++ b/packages/dataparcels/src/parcel/__test__/ModifyMethods-test.js
@@ -247,7 +247,15 @@ test('Parcel.initialMeta() should work', () => {
         handleChange
     }).initialMeta({a:1, b:2});
 
-    expect(parcel.meta).toEqual({a:1, b:2});
+    expect(parcel.data).toEqual({
+        value: 123,
+        meta: {
+            a: 1,
+            b: 2
+        },
+        child: undefined,
+        key: "^"
+    });
 
     parcel.setMeta({b: 3});
 
@@ -272,7 +280,16 @@ test('Parcel.initialMeta() should merge', () => {
         .initialMeta({a:1, b:2})
         .initialMeta({b:3, c:4})
 
-    expect(parcel.meta).toEqual({a:1, b:2, c:4});
+    expect(parcel.data).toEqual({
+        value: 123,
+        meta: {
+            a: 1,
+            b: 2,
+            c: 4
+        },
+        child: undefined,
+        key: "^"
+    });
 
     parcel.setMeta({d: 5});
 
@@ -283,6 +300,27 @@ test('Parcel.initialMeta() should merge', () => {
             b: 2,
             c: 4,
             d: 5
+        },
+        child: undefined,
+        key: "^"
+    });
+});
+
+test('Parcel.initialMeta() should do nothing to data if all meta keys are already set', () => {
+    let handleChange = jest.fn();
+
+    let parcel = new Parcel({
+        value: 123,
+        handleChange
+    })
+        .initialMeta({a:1, b:2})
+        .initialMeta({a:1, b:2}) // do nothing to data
+
+    expect(parcel.data).toEqual({
+        value: 123,
+        meta: {
+            a: 1,
+            b: 2
         },
         child: undefined,
         key: "^"


### PR DESCRIPTION
## dataparcels
- fix: prevent value from being removed if `Parcel.initialMeta` is set #164 
- No breaking changes

## react-dataparcels
- No change