### PR TITLE
Add: Parcel.move() and react-sortable-hoc example

### DIFF
--- a/packages/dataparcels-docs/package.json
+++ b/packages/dataparcels-docs/package.json
@@ -31,6 +31,7 @@
     "react-flip-move": "^3.0.2",
     "react-helmet": "^5.2.0",
     "react-lifecycles-compat": "^3.0.4",
+    "react-sortable-hoc": "^1.4.0",
     "stampy": "^0.41.0",
     "unmutable": "^0.29.2"
   }

--- a/packages/dataparcels-docs/src/docs/api/parcel/move.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/move.md
@@ -1,0 +1,4 @@
+```flow
+move(key: string|number): void // only on ElementParcels, will move with sibling
+move(keyA: string|number, keyB: string|number): void // only on IndexedParcels, will move children
+```

--- a/packages/dataparcels-docs/src/docs/api/parcelShape/move.md
+++ b/packages/dataparcels-docs/src/docs/api/parcelShape/move.md
@@ -1,0 +1,4 @@
+```flow
+move(key: string|number): void // only on ElementParcels, will move with sibling
+move(keyA: string|number, keyB: string|number): void // only on IndexedParcels, will move children
+```

--- a/packages/dataparcels-docs/src/examples/EditingArraysSortableHoc.jsx
+++ b/packages/dataparcels-docs/src/examples/EditingArraysSortableHoc.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import {ParcelHoc, ParcelBoundary} from 'react-dataparcels';
+import {SortableContainer, SortableElement} from 'react-sortable-hoc';
+import ExampleHoc from 'component/ExampleHoc';
+
+const FruitListParcelHoc = ParcelHoc({
+    name: "fruitListParcel",
+    valueFromProps: (/* props */) => [
+        "Apple",
+        "Banana",
+        "Crumpets"
+    ]
+});
+
+const SortableFruitItem = SortableElement(({fruitParcel}) => {
+    return <ParcelBoundary parcel={fruitParcel}>
+        {(parcel) => <div className="Box-draggable Typography">
+            <input type="text" {...parcel.spreadDOM()} />
+            <button onClick={() => parcel.insertAfter(`${parcel.value} copy`)}>+</button>
+            <button onClick={() => parcel.delete()}>x</button>
+        </div>}
+    </ParcelBoundary>;
+});
+
+const SortableFruitList = SortableContainer(({fruitListParcel}) => {
+    return <div>
+        {fruitListParcel.toArray((fruitParcel, index) => {
+            return <SortableFruitItem
+                key={fruitParcel.key}
+                index={index}
+                fruitParcel={fruitParcel}
+            />;
+        })}
+    </div>;
+});
+
+const FruitListEditor = (props) => {
+    let {fruitListParcel} = props;
+    return <div>
+        <SortableFruitList
+            fruitListParcel={fruitListParcel}
+            onSortEnd={({oldIndex, newIndex}) => fruitListParcel.move(oldIndex, newIndex)}
+        />
+        <button onClick={() => fruitListParcel.push("New fruit")}>Add new fruit</button>
+    </div>;
+};
+
+export default FruitListParcelHoc(ExampleHoc(FruitListEditor));

--- a/packages/dataparcels-docs/src/layouts/index.scss
+++ b/packages/dataparcels-docs/src/layouts/index.scss
@@ -6,6 +6,23 @@
 
 @include DcmeBase;
 @include DcmeBox {
+    &-draggable {
+        cursor: move;
+        padding-left: 1rem;
+        position: relative;
+
+        &:after {
+            color: grey(70);
+            content: '.. .. .. ..';
+            display: block;
+            font-size: 1.2rem;
+            left: 0;
+            line-height: 5px;
+            position: absolute;
+            top: 0;
+            width: 1rem;
+        }
+    }
     &-example {
         margin-left: -2rem;
         margin-right: -2rem;
@@ -63,5 +80,31 @@
             -12px 12px 0px lighten(color('primary'), 30)
     }
 }
-@include DcmeTypography;
+@include DcmeTypography {
+    input {
+        background: #FFF;
+    }
+}
 @include DcmeWrapper;
+
+// .DragHandle {
+//   content: '....';
+//   width: 10px;
+//   height: 20px;
+//   display: inline-block;
+//   overflow: hidden;
+//   line-height: 5px;
+//   padding: 3px 4px;
+//   cursor: move;
+//   vertical-align: middle;
+//   margin-top: -.7em;
+//   margin-right: .3em;
+//   font-size: 12px;
+//   font-family: sans-serif;
+//   letter-spacing: 2px;
+//   color: #cccccc;
+//   text-shadow: 1px 0 1px black;
+// }
+// .DragHandle::after {
+//   content: '.. .. .. ..';
+// }

--- a/packages/dataparcels-docs/src/pages/api/Parcel.jsx
+++ b/packages/dataparcels-docs/src/pages/api/Parcel.jsx
@@ -33,6 +33,7 @@ import Markdown_delete from 'docs/api/parcel/delete.md';
 import Markdown_deleteIn from 'docs/api/parcel/deleteIn.md';
 import Markdown_insertAfter from 'docs/api/parcel/insertAfter.md';
 import Markdown_insertBefore from 'docs/api/parcel/insertBefore.md';
+import Markdown_move from 'docs/api/parcel/move.md';
 import Markdown_pop from 'docs/api/parcel/pop.md';
 import Markdown_push from 'docs/api/parcel/push.md';
 import Markdown_shift from 'docs/api/parcel/shift.md';
@@ -95,6 +96,7 @@ const md = {
     deleteIn: Markdown_deleteIn,
     insertAfter: Markdown_insertAfter,
     insertBefore: Markdown_insertBefore,
+    move: Markdown_move,
     pop: Markdown_pop,
     push: Markdown_push,
     shift: Markdown_shift,
@@ -165,6 +167,7 @@ updateShapeIn()
 # Indexed & element change methods
 insertAfter()
 insertBefore()
+move()
 push()
 pop()
 shift()

--- a/packages/dataparcels-docs/src/pages/api/ParcelShape.jsx
+++ b/packages/dataparcels-docs/src/pages/api/ParcelShape.jsx
@@ -24,6 +24,7 @@ import Markdown_delete from 'docs/api/parcelShape/delete.md';
 import Markdown_deleteIn from 'docs/api/parcelShape/deleteIn.md';
 import Markdown_insertAfter from 'docs/api/parcelShape/insertAfter.md';
 import Markdown_insertBefore from 'docs/api/parcelShape/insertBefore.md';
+import Markdown_move from 'docs/api/parcelShape/move.md';
 import Markdown_pop from 'docs/api/parcelShape/pop.md';
 import Markdown_push from 'docs/api/parcelShape/push.md';
 import Markdown_shift from 'docs/api/parcelShape/shift.md';
@@ -62,6 +63,7 @@ const md = {
     deleteIn: Markdown_deleteIn,
     insertAfter: Markdown_insertAfter,
     insertBefore: Markdown_insertBefore,
+    move: Markdown_move,
     pop: Markdown_pop,
     push: Markdown_push,
     shift: Markdown_shift,
@@ -107,6 +109,7 @@ updateShapeIn()
 # Indexed & element change methods
 insertAfter()
 insertBefore()
+move()
 push()
 pop()
 shift()

--- a/packages/dataparcels-docs/src/pages/examples/editing-arrays.md
+++ b/packages/dataparcels-docs/src/pages/examples/editing-arrays.md
@@ -1,6 +1,7 @@
 import Link from 'gatsby-link';
 import EditingArrays from 'examples/EditingArrays';
 import EditingArraysFlipMove from 'examples/EditingArraysFlipMove';
+import EditingArraysSortableHoc from 'examples/EditingArraysSortableHoc';
 
 Dataparcels has a powerful set of methods for manipulating indexed data types, such as arrays. This example demonstrates an editor that allows the user to edit, append to and sort the elements in an array of strings.
 
@@ -50,9 +51,65 @@ export default FruitListParcelHoc(FruitListEditor);
 
 For the full list of methods you can use on indexed data types, see <Link to="/api/Parcel#indexed_change_methods">Indexed Change Methods</Link> and <Link to="/api/Parcel#element_change_methods">Element Change Methods</Link> in the Parcel API reference.
 
+## With react-sortable-hoc
+
+Dataparcels' `move()` method plays nicely with [react-sortable-hoc](https://github.com/clauderic/react-sortable-hoc).
+
+<EditingArraysSortableHoc />
+
+```js
+import React from 'react';
+import {ParcelHoc, ParcelBoundary} from 'react-dataparcels';
+import {SortableContainer, SortableElement} from 'react-sortable-hoc';
+
+const FruitListParcelHoc = ParcelHoc({
+    name: "fruitListParcel",
+    valueFromProps: (/* props */) => [
+        "Apple",
+        "Banana",
+        "Crumpets"
+    ]
+});
+
+const SortableFruitItem = SortableElement(({fruitParcel}) => {
+    return <ParcelBoundary parcel={fruitParcel}>
+        {(parcel) => <div>
+            <input type="text" {...parcel.spreadDOM()} />
+            <button onClick={() => parcel.insertAfter(`${parcel.value} copy`)}>+</button>
+            <button onClick={() => parcel.delete()}>x</button>
+        </div>}
+    </ParcelBoundary>;
+});
+
+const SortableFruitList = SortableContainer(({fruitListParcel}) => {
+    return <div>
+        {fruitListParcel.toArray((fruitParcel, index) => {
+            return <SortableFruitItem
+                key={fruitParcel.key}
+                index={index}
+                fruitParcel={fruitParcel}
+            />;
+        })}
+    </div>;
+});
+
+const FruitListEditor = (props) => {
+    let {fruitListParcel} = props;
+    return <div>
+        <SortableFruitList
+            fruitListParcel={fruitListParcel}
+            onSortEnd={({oldIndex, newIndex}) => fruitListParcel.move(oldIndex, newIndex)}
+        />
+        <button onClick={() => fruitListParcel.push("New fruit")}>Add new fruit</button>
+    </div>;
+};
+
+export default FruitListParcelHoc(FruitListEditor);
+```
+
 ## With react-flip-move
 
-Dataparcels automatic keying plays nicely with [react-flip-move](https://github.com/joshwcomeau/react-flip-move).
+Dataparcels' automatic keying also plays nicely with [react-flip-move](https://github.com/joshwcomeau/react-flip-move).
 
 <EditingArraysFlipMove />
 

--- a/packages/dataparcels-docs/src/pages/examples/editing-arrays.md
+++ b/packages/dataparcels-docs/src/pages/examples/editing-arrays.md
@@ -51,9 +51,9 @@ export default FruitListParcelHoc(FruitListEditor);
 
 For the full list of methods you can use on indexed data types, see <Link to="/api/Parcel#indexed_change_methods">Indexed Change Methods</Link> and <Link to="/api/Parcel#element_change_methods">Element Change Methods</Link> in the Parcel API reference.
 
-## With react-sortable-hoc
+## Drag and drop with react-sortable-hoc
 
-Dataparcels' `move()` method plays nicely with [react-sortable-hoc](https://github.com/clauderic/react-sortable-hoc).
+Dataparcels' plays nicely with [react-sortable-hoc](https://github.com/clauderic/react-sortable-hoc). Drag items up and fown to change their order.
 
 <EditingArraysSortableHoc />
 
@@ -107,9 +107,9 @@ const FruitListEditor = (props) => {
 export default FruitListParcelHoc(FruitListEditor);
 ```
 
-## With react-flip-move
+## Animations with react-flip-move
 
-Dataparcels' automatic keying also plays nicely with [react-flip-move](https://github.com/joshwcomeau/react-flip-move).
+Dataparcels' also plays nicely with [react-flip-move](https://github.com/joshwcomeau/react-flip-move) because of its automatic keying. Add, remove and move items to see.
 
 <EditingArraysFlipMove />
 

--- a/packages/dataparcels/src/change/ActionCreators.js
+++ b/packages/dataparcels/src/change/ActionCreators.js
@@ -49,6 +49,25 @@ const insertBeforeSelf: Function = (value: *): Action => {
     });
 };
 
+const move: Function = (keyA: Key|Index, keyB: Key|Index): Action => {
+    return new Action({
+        type: "move",
+        keyPath: [keyA],
+        payload: {
+            moveKey: keyB
+        }
+    });
+};
+
+const moveSelf: Function = (keyB: Key|Index): Action => {
+    return new Action({
+        type: "move",
+        payload: {
+            moveKey: keyB
+        }
+    });
+};
+
 const push: Function = (values: Array<*>): Action => {
     return new Action({
         type: "push",
@@ -155,6 +174,8 @@ export default {
     insertAfterSelf,
     insertBefore,
     insertBeforeSelf,
+    move,
+    moveSelf,
     push,
     pop,
     setData,

--- a/packages/dataparcels/src/change/ChangeRequestReducer.js
+++ b/packages/dataparcels/src/change/ChangeRequestReducer.js
@@ -10,12 +10,12 @@ import pipe from 'unmutable/lib/util/pipe';
 import composeWith from 'unmutable/lib/util/composeWith';
 
 import {ReducerInvalidActionError} from '../errors/Errors';
-import {ReducerSwapKeyError} from '../errors/Errors';
 
 import del from '../parcelData/delete';
 import deleteSelfWithMarker from '../parcelData/deleteSelfWithMarker';
 import insertAfter from '../parcelData/insertAfter';
 import insertBefore from '../parcelData/insertBefore';
+import move from '../parcelData/move';
 import pop from '../parcelData/pop';
 import push from '../parcelData/push';
 import setMeta from '../parcelData/setMeta';
@@ -31,18 +31,14 @@ const actionMap = {
     delete: ({lastKey}) => del(lastKey),
     insertAfter: ({lastKey, value}) => insertAfter(lastKey, value),
     insertBefore: ({lastKey, value}) => insertBefore(lastKey, value),
+    move: ({lastKey, moveKey}) => move(lastKey, moveKey),
     pop: () => pop(),
     push: ({values}) => push(...values),
     setData: parcelData => () => parcelData,
     setMeta: ({meta}) => setMeta(meta),
     set: ({value}) => setSelf(value),
     shift: () => shift(),
-    swap: ({lastKey, swapKey}: any): ParcelDataEvaluator => {
-        if(typeof swapKey === "undefined") {
-            throw ReducerSwapKeyError();
-        }
-        return swap(lastKey, swapKey);
-    },
+    swap: ({lastKey, swapKey}) => swap(lastKey, swapKey),
     swapNext: ({lastKey}) => swapNext(lastKey),
     swapPrev: ({lastKey}) => swapPrev(lastKey),
     unshift: ({values}) => unshift(...values)
@@ -52,6 +48,7 @@ const parentActionMap = {
     delete: true,
     insertAfter: true,
     insertBefore: true,
+    move: true,
     swap: true,
     swapNext: true,
     swapPrev: true

--- a/packages/dataparcels/src/change/__test__/ChangeRequestReducerIndexed-test.js
+++ b/packages/dataparcels/src/change/__test__/ChangeRequestReducerIndexed-test.js
@@ -23,6 +23,7 @@ let EXPECTED_KEY_AND_META = {
 [
     "insertAfter",
     "insertBefore",
+    "move",
     "swap",
     "swapNext",
     "swapPrev"
@@ -30,15 +31,6 @@ let EXPECTED_KEY_AND_META = {
     test(`Reducer ${type} action should return unchanged parcelData if keyPath is empty`, () => {
         expect(makeReducer(new Action({type}))(data)).toEqual(data);
     });
-});
-
-test('Reducer swap action should throw error if payload.swapKey doesnt exist', () => {
-    let action = new Action({
-        type: "swap",
-        keyPath: [0]
-    });
-
-    expect(() => makeReducer(action)(data)).toThrowError(`swap actions must have a swapKey in their payload`);
 });
 
 const TestIndex = (arr) => arr.map(({action, expectedData}) => {
@@ -234,6 +226,23 @@ TestIndex([
         expectedData: {
             value: [3,0,1,2],
             child: [{key: "#d"},{key: "#a"},{key: "#b"}, {key: "#c"}],
+            ...EXPECTED_KEY_AND_META
+        }
+    }
+]);
+
+TestIndex([
+    {
+        action: {
+            type: "move",
+            payload: {
+                moveKey: 0
+            },
+            keyPath: [2]
+        },
+        expectedData: {
+            value: [2,0,1],
+            child: [{key: "#c"},{key: "#a"}, {key: "#b"}],
             ...EXPECTED_KEY_AND_META
         }
     }

--- a/packages/dataparcels/src/errors/Errors.js
+++ b/packages/dataparcels/src/errors/Errors.js
@@ -2,7 +2,6 @@
 
 export const ReadOnlyError = () => new Error(`This property is read-only`);
 export const ReducerInvalidActionError = (actionType: string) => new Error(`"${actionType}" is not a valid action`);
-export const ReducerSwapKeyError = () =>  new Error(`swap actions must have a swapKey in their payload`);
 export const UnsafeValueUpdaterError = () =>  new Error(`Value updaters can only pass collections through if the collection is unchanged by the updater. Consider using a deep updater method (e.g. <method name>Deep()) for updating collections.`);
 export const ChangeRequestUnbasedError = () =>  new Error(`ChangeRequest data cannot be accessed before calling changeRequest._setBaseParcel()`);
 export const ShapeUpdaterNonShapeChildError = () =>  new Error(`Every child value on a collection returned from a shape updater must be a ParcelShape`);

--- a/packages/dataparcels/src/parcel/Parcel.js
+++ b/packages/dataparcels/src/parcel/Parcel.js
@@ -315,6 +315,10 @@ export default class Parcel {
         ["1"]: (value: any) => this._methods.insertBeforeSelf(value),
         ["2"]: (key: Key|Index, value: any) => this._methods.insertBefore(key, value)
     });
+    move = overload({
+        ["1"]: (key: Key|Index) => this._methods.moveSelf(key),
+        ["2"]: (keyA: Key|Index, keyB: Key|Index) => this._methods.move(keyA, keyB)
+    });
     push = (...values: Array<any>) => this._methods.push(...values);
     pop = () => this._methods.pop();
     shift = () => this._methods.shift();

--- a/packages/dataparcels/src/parcel/__test__/ElementParcelMethods-test.js
+++ b/packages/dataparcels/src/parcel/__test__/ElementParcelMethods-test.js
@@ -109,6 +109,48 @@ test('ElementParcel.insertAfter() should insert', () => {
         .insertAfter(4);
 });
 
+test('ElementParcel.move() should move', () => {
+    expect.assertions(2);
+
+    var data = {
+        value: [1,2,3],
+        child: [
+            {key: "#a"},
+            {key: "#b"},
+            {key: "#c"}
+        ]
+    };
+
+    var expectedData = {
+        meta: {},
+        value: [3,1,2],
+        key: '^',
+        child: [
+            {key: "#c"},
+            {key: "#a"},
+            {key: "#b"}
+        ]
+    };
+
+    var expectedAction = {
+        type: "move",
+        keyPath: ["#c"],
+        payload: {
+            moveKey: 0
+        }
+    };
+
+    new Parcel({
+        ...data,
+        handleChange: (parcel, changeRequest) => {
+            expect(expectedData).toEqual(parcel.data);
+            expect(expectedAction).toEqual(GetAction(changeRequest));
+        }
+    })
+        .get(2)
+        .move(0);
+});
+
 test('ElementParcel.swap() should swap', () => {
     expect.assertions(2);
 

--- a/packages/dataparcels/src/parcel/__test__/IndexedParcelMethods-test.js
+++ b/packages/dataparcels/src/parcel/__test__/IndexedParcelMethods-test.js
@@ -190,6 +190,46 @@ test('IndexedParcel.insertAfter() should insertAfter', () => {
     expect(GetAction(keyedHandleChange.mock.calls[0][1])).toEqual(expectedActionWithKey);
 });
 
+test('IndexedParcel.move() should move', () => {
+    expect.assertions(2);
+
+    var data = {
+        value: [1,2,3],
+        child: [
+            {key: "#a"},
+            {key: "#b"},
+            {key: "#c"}
+        ]
+    };
+
+    var expectedData = {
+        meta: {},
+        value: [3,1,2],
+        key: '^',
+        child: [
+            {key: "#c"},
+            {key: "#a"},
+            {key: "#b"}
+        ]
+    };
+
+    var expectedAction = {
+        type: "move",
+        keyPath: [2],
+        payload: {
+            moveKey: 0
+        }
+    };
+
+    new Parcel({
+        ...data,
+        handleChange: (parcel, changeRequest) => {
+            expect(expectedData).toEqual(parcel.data);
+            expect(expectedAction).toEqual(GetAction(changeRequest));
+        }
+    }).move(2,0);
+});
+
 test('IndexedParcel.push() should push', () => {
     expect.assertions(2);
 

--- a/packages/dataparcels/src/parcel/methods/ElementChangeMethods.js
+++ b/packages/dataparcels/src/parcel/methods/ElementChangeMethods.js
@@ -16,6 +16,11 @@ export default (_this: Parcel, dispatch: Function): Object => ({
         dispatch(ActionCreators.insertBeforeSelf(value));
     },
 
+    moveSelf: (key: Key|Index) => {
+        Types(`moveSelf()`, `key`, `keyIndex`)(key);
+        dispatch(ActionCreators.moveSelf(key));
+    },
+
     swapNextSelf: () => {
         dispatch(ActionCreators.swapNextSelf());
     },

--- a/packages/dataparcels/src/parcel/methods/IndexedChangeMethods.js
+++ b/packages/dataparcels/src/parcel/methods/IndexedChangeMethods.js
@@ -18,6 +18,12 @@ export default (_this: Parcel, dispatch: Function): Object => ({
         dispatch(ActionCreators.insertBefore(key, value));
     },
 
+    move: (keyA: Key|Index, keyB: Key|Index) => {
+        Types(`move()`, `keyA`, `keyIndex`)(keyA);
+        Types(`move()`, `keyB`, `keyIndex`)(keyB);
+        dispatch(ActionCreators.move(keyA, keyB));
+    },
+
     push: (...values: Array<*>) => {
         dispatch(ActionCreators.push(values));
     },

--- a/packages/dataparcels/src/parcelData/move.js
+++ b/packages/dataparcels/src/parcelData/move.js
@@ -1,3 +1,3 @@
 // @flow
 import swapOrMove from './swapOrMove';
-export default swapOrMove('swap');
+export default swapOrMove('move');

--- a/packages/dataparcels/src/parcelData/swapOrMove.js
+++ b/packages/dataparcels/src/parcelData/swapOrMove.js
@@ -1,0 +1,33 @@
+// @flow
+import type {Index} from '../types/Types';
+import type {Key} from '../types/Types';
+import type {ParcelData} from '../types/Types';
+
+import prepareChildKeys from './prepareChildKeys';
+import keyOrIndexToIndex from './keyOrIndexToIndex';
+
+import move from 'unmutable/lib/move';
+import swap from 'unmutable/lib/swap';
+
+export default (swapOrMove: string): Function => {
+    let fn = swapOrMove === 'swap' ? swap : move;
+    return (keyA: Key|Index, keyB: Key|Index) => (parcelData: ParcelData): ParcelData => {
+
+        let parcelDataWithChildKeys = prepareChildKeys()(parcelData);
+
+        let indexA: ?Index = keyOrIndexToIndex(keyA)(parcelDataWithChildKeys);
+        let indexB: ?Index = keyOrIndexToIndex(keyB)(parcelDataWithChildKeys);
+
+        if(typeof indexA === "undefined" || typeof indexB === "undefined") {
+            return parcelData;
+        }
+
+        let {value, child} = parcelDataWithChildKeys;
+
+        return {
+            ...parcelDataWithChildKeys,
+            value: fn(indexA, indexB)(value),
+            child: fn(indexA, indexB)(child)
+        };
+    };
+};

--- a/packages/dataparcels/src/parcelShape/ParcelShape.js
+++ b/packages/dataparcels/src/parcelShape/ParcelShape.js
@@ -187,6 +187,7 @@ export default class ParcelShape {
     // Indexed methods
     insertAfter = (key: Key|Index, value: any) => this._methods.insertAfter(key, value);
     insertBefore = (key: Key|Index, value: any) => this._methods.insertBefore(key, value);
+    move = (keyA: Key|Index, keyB: Key|Index) => this._methods.move(keyA, keyB);
     push = (...values: Array<any>) => this._methods.push(...values);
     pop = () => this._methods.pop();
     shift = () => this._methods.shift();

--- a/packages/dataparcels/src/parcelShape/__test__/ParcelShapeIndexedSetMethods-test.js
+++ b/packages/dataparcels/src/parcelShape/__test__/ParcelShapeIndexedSetMethods-test.js
@@ -17,6 +17,14 @@ test('ParcelShapes insertBefore(key, value) should work', () => {
     expect(staticParcel.insertBefore(0, 3).data.value).toEqual([3,0,1,2]);
 });
 
+test('ParcelShapes move() should work', () => {
+    let staticParcel = ParcelShape.fromData({
+        value: [0,1,2]
+    });
+
+    expect(staticParcel.move(2,0).data.value).toEqual([2,0,1]);
+});
+
 test('ParcelShapes push(value) should work', () => {
     let staticParcel = ParcelShape.fromData({
         value: [0,1,2]

--- a/packages/dataparcels/src/parcelShape/methods/ParcelShapeIndexedSetMethods.js
+++ b/packages/dataparcels/src/parcelShape/methods/ParcelShapeIndexedSetMethods.js
@@ -5,6 +5,7 @@ import type ParcelShape from '../ParcelShape';
 
 import insertAfter from '../../parcelData/insertAfter';
 import insertBefore from '../../parcelData/insertBefore';
+import move from '../../parcelData/move';
 import pop from '../../parcelData/pop';
 import push from '../../parcelData/push';
 import shift from '../../parcelData/shift';
@@ -26,6 +27,13 @@ export default (_this: ParcelShape) => ({
         _this._prepareChildKeys();
         return _this._pipeSelf(
             insertBefore(key, value)
+        );
+    },
+
+    move: (keyA: Key|Index, keyB: Key|Index): ParcelShape => {
+        _this._prepareChildKeys();
+        return _this._pipeSelf(
+            move(keyA, keyB)
         );
     },
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -96,6 +96,12 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+"@babel/runtime@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.2.0.tgz#b03e42eeddf5898e00646e4c840fa07ba8dcad7f"
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
 "@babel/template@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.44.tgz#f8832f4fdcee5d59bf515e595fc5106c529b394f"
@@ -11184,6 +11190,14 @@ react-side-effect@^1.1.0:
     exenv "^1.2.1"
     shallowequal "^1.0.1"
 
+react-sortable-hoc@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/react-sortable-hoc/-/react-sortable-hoc-1.4.0.tgz#b477ce700ba755754200a1dabd36e588e2f5608d"
+  dependencies:
+    "@babel/runtime" "^7.2.0"
+    invariant "^2.2.4"
+    prop-types "^15.5.7"
+
 react-spruce@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/react-spruce/-/react-spruce-0.1.0.tgz#e1b048e5e5c445b867215be2c48fff034a38f667"
@@ -11426,6 +11440,10 @@ regenerator-runtime@^0.10.0, regenerator-runtime@^0.10.5:
 regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
+
+regenerator-runtime@^0.12.0:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
 
 regenerator-transform@^0.10.0:
   version "0.10.1"


### PR DESCRIPTION
## dataparcels
- add: `Parcel.move()` #117
- add: `ParcelShape.move()` #117
- refactor: remove internal error warning about missing `swapKey` in swap action
- No breaking changes

## react-dataparcels
- No change

## dataparcels-docs
- Add react-sortable-hoc example #117