### PR TITLE
Feature/shape updaters

### DIFF
--- a/packages/dataparcels/src/errors/Errors.js
+++ b/packages/dataparcels/src/errors/Errors.js
@@ -5,3 +5,4 @@ export const ReducerInvalidActionError = (actionType: string) => new Error(`"${a
 export const UnsafeValueUpdaterError = () =>  new Error(`Value updaters can only pass collections through if the collection is unchanged by the updater. Consider using a deep updater method (e.g. <method name>Deep()) for updating collections.`);
 export const ChangeRequestUnbasedError = () =>  new Error(`ChangeRequest data cannot be accessed before calling changeRequest._setBaseParcel()`);
 export const ShapeUpdaterNonShapeChildError = () =>  new Error(`Every child value on a collection returned from a shape updater must be a ParcelShape`);
+export const ShapeUpdaterUndefinedError = () =>  new Error(`ShapeUpdaterUndefinedError`);

--- a/packages/dataparcels/src/parcel/__test__/ParcelChangeMethods-test.js
+++ b/packages/dataparcels/src/parcel/__test__/ParcelChangeMethods-test.js
@@ -105,6 +105,32 @@ test('Parcel.updateShape() should call the Parcels handleChange function with th
     expect(handleChange.mock.calls[0][0].data.value).toEqual([1,2,3,4]);
 });
 
+test('Parcel.updateShape() should work with a returned primitive', () => {
+
+    let handleChange = jest.fn();
+    let updater = jest.fn(() => 123);
+
+    new Parcel({
+        value: [1,2,3],
+        handleChange
+    }).updateShape(updater);
+
+    expect(handleChange.mock.calls[0][0].data.value).toEqual(123);
+});
+
+test('Parcel.updateShape() should work with a returned collection containing parcels for children', () => {
+
+    let handleChange = jest.fn();
+    let updater = jest.fn(parcelShape => parcelShape.children().reverse());
+
+    new Parcel({
+        value: [1,2,3],
+        handleChange
+    }).updateShape(updater);
+
+    expect(handleChange.mock.calls[0][0].data.value).toEqual([3,2,1]);
+});
+
 test('Parcel.onChange() should work like set that only accepts a single argument', () => {
     expect.assertions(2);
 

--- a/packages/dataparcels/src/parcelShape/ParcelShape.js
+++ b/packages/dataparcels/src/parcelShape/ParcelShape.js
@@ -10,6 +10,7 @@ import type {ParcelShapeSetMeta} from '../types/Types';
 
 import Types from '../types/Types';
 import {ReadOnlyError} from '../errors/Errors';
+import {ShapeUpdaterUndefinedError} from '../errors/Errors';
 
 import ParcelTypes from '../parcel/ParcelTypes';
 import ParcelId from '../parcelId/ParcelId';
@@ -76,6 +77,21 @@ export default class ParcelShape {
             .fromData(parcelData)
             .updateShape(updater)
             .data;
+    }
+
+    static _updateFromDataUnlessUndefined(updater: ParcelShapeUpdater): Function {
+        return (parcelData: ParcelData): ParcelData => {
+            let parcelShape: ParcelShape = ParcelShape.fromData(parcelData);
+
+            let updated: any = updater(parcelShape);
+            if(updated === undefined) {
+                throw ShapeUpdaterUndefinedError();
+            }
+
+            return parcelShape
+                .updateShape(() => updated)
+                .data;
+        };
     }
 
     // only need this to reference static methods on ParcelShape


### PR DESCRIPTION
## dataparcels

- amend ability for `Parcel.modifyShapeUp()` to halt change propagation when undefined is returned
- improve shape tests
- **Note for future development:** *Once cache exists, consider if the reducer might have to have similar behaviour.*

## react-dataparcels
- no change