### PR TITLE
Fix: modifyValue and modifyChangeValue warning

### DIFF
--- a/packages/dataparcels/src/errors/Errors.js
+++ b/packages/dataparcels/src/errors/Errors.js
@@ -3,6 +3,4 @@
 export const ReadOnlyError = () => new Error(`This property is read-only`);
 export const ReducerInvalidActionError = (actionType: string) => new Error(`"${actionType}" is not a valid action`);
 export const ReducerSwapKeyError = () =>  new Error(`swap actions must have a swapKey in their payload`);
-export const ModifyValueChildReturnError = () =>  new Error(`.modifyValue()'s updater can not return a value that has children unless it is unchanged by the updater or is empty.`);
-export const ModifyValueChangeChildReturnError = () =>  new Error(`When .modifyChangeValue()'s updater is passed a value that has children, it cannot return a value that has children unless it is unchanged by the updater`);
 export const ChangeRequestUnbasedError = () =>  new Error(`ChangeRequest data cannot be accessed before calling changeRequest._setBaseParcel()`);

--- a/packages/dataparcels/src/parcel/__test__/ModifyMethods-test.js
+++ b/packages/dataparcels/src/parcel/__test__/ModifyMethods-test.js
@@ -54,24 +54,6 @@ test('Parcel.modifyValue() should allow parent types to be returned if they dont
     expect(updatedValue).toEqual([123]);
 });
 
-test('Parcel.modifyValue() should throw error if changed parent types with children are returned', () => {
-    expect(() => {
-        new Parcel({
-            value: [123]
-        }).modifyValue(value => [...value, 456]);
-
-    }).toThrowError(`modifyValue()`);
-});
-
-test('Parcel.modifyValue() should throw error if childless is turned into parent types with children', () => {
-    expect(() => {
-        new Parcel({
-            value: 123
-        }).modifyValue(value => [123, 456]);
-
-    }).toThrowError(`modifyValue()`);
-});
-
 test('Parcel.modifyValue() should recognise if value changes types, and set value if type changes', () => {
     let handleChange = jest.fn();
     let parcel = new Parcel({
@@ -177,19 +159,6 @@ test('Parcel.modifyChangeValue() should allow parent types to be returned if the
         .onChange([456]);
 
     expect(handleChange.mock.calls[0][0].value).toEqual([456]);
-});
-
-test('Parcel.modifyChangeValue() should throw error if changed parent types with children are returned', () => {
-    expect(() => {
-        var handleChange = jest.fn();
-        new Parcel({
-            value: [123],
-            handleChange
-        })
-            .modifyChangeValue(value => [...value, 456])
-            .onChange([456]);
-
-    }).toThrowError(`modifyChangeValue()`);
 });
 
 test('Parcel.modifyChangeValue() should allow changes to meta through', () => {

--- a/packages/dataparcels/src/parcel/methods/ModifyMethods.js
+++ b/packages/dataparcels/src/parcel/methods/ModifyMethods.js
@@ -5,8 +5,6 @@ import type {ParcelMeta} from '../../types/Types';
 import Types from '../../types/Types';
 
 import ParcelTypes from '../ParcelTypes';
-import {ModifyValueChildReturnError} from '../../errors/Errors';
-import {ModifyValueChangeChildReturnError} from '../../errors/Errors';
 import HashString from '../../util/HashString';
 
 import equals from 'unmutable/lib/equals';
@@ -30,8 +28,8 @@ export default (_this: Parcel): Object => ({
         let updatedValue = updater(value, _this);
         let updatedType = new ParcelTypes(updatedValue);
 
-        if(updatedType.isParent() && !isEmpty()(updatedValue) && !equals(value)(updatedValue)) {
-            throw ModifyValueChildReturnError();
+        if(process.env.NODE_ENV !== 'production' && updatedType.isParent() && !isEmpty()(updatedValue) && !equals(value)(updatedValue)) {
+            console.warn(`modifyValue(): please ensure you do not change the shape of the value, as changing the data shape or moving children within the data shape can cause dataparcels to misplace its keying and meta information.`); /* eslint-disable-line */
         }
 
         let updatedTypeChanged: boolean = updatedType.isParent() !== _this._parcelTypes.isParent()
@@ -83,8 +81,8 @@ export default (_this: Parcel): Object => ({
             let updatedValue = updater(value, _this);
 
             if(type.isParent()) {
-                if(!equals(value)(updatedValue)) {
-                    throw ModifyValueChangeChildReturnError();
+                if(process.env.NODE_ENV !== 'production' && !equals(value)(updatedValue)) {
+                    console.warn(`modifyChangeValue(): please ensure you do not change the shape of the value, as changing the data shape or moving children within the data shape can cause dataparcels to misplace its keying and meta information.`); /* eslint-disable-line */
                 }
                 parcel.dispatch(changeRequest);
                 return;


### PR DESCRIPTION
- fix: replace modifyValue and modifyChangeValue parent inequality errors with warnings in dev mode

This is a fix because this behaviour accidentally broke an untested use case, with no alternative.