### PR TITLE
Feature/checkbox

### DIFF
--- a/packages/dataparcels-docs/src/docs/api/parcel/onChange.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/onChange.md
@@ -25,7 +25,8 @@ let parcel = new Parcel({
 
 <Box modifier="margin">
     <Message>See also:
-        <Text element="div">- <Link href="#onChangeDOM">onChangeDOM</Link> for use with HTML inputs</Text>
         <Text element="div">- <Link href="#spread">spread</Link> for convenient spreading of value and onChange onto an input</Text>
+        <Text element="div">- <Link href="#onChangeDOM">onChangeDOM</Link> for use with HTML inputs</Text>
+        <Text element="div">- <Link href="#onChangeDOMCheckbox">onChangeDOMCheckbox</Link> for use with HTML checkboxes</Text>
     </Message>
 </Box>

--- a/packages/dataparcels-docs/src/docs/api/parcel/onChangeDOM.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/onChangeDOM.md
@@ -23,7 +23,8 @@ let parcel = new Parcel({
 
 <Box modifier="margin">
     <Message>See also:
-        <Text element="div">- <Link href="#onChangeDOM">onChangeDOM</Link> for use with input components that call `onChange` with a new value.</Text>
-        <Text element="div">- <Link href="#spread">spreadDOM</Link> for convenient spreading of value and onChange onto an input</Text>
+        <Text element="div">- <Link href="#spreadDOM">spreadDOM</Link> for convenient spreading of value and onChangeDOM onto an input</Text>
+        <Text element="div">- <Link href="#onChange">onChange</Link> for use with input components that call `onChange` with a new value.</Text>
+        <Text element="div">- <Link href="#onChangeDOMCheckbox">onChangeDOMCheckbox</Link> for use with HTML checkboxes</Text>
     </Message>
 </Box>

--- a/packages/dataparcels-docs/src/docs/api/parcel/onChangeDOMCheckbox.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/onChangeDOMCheckbox.md
@@ -1,0 +1,28 @@
+import {Box, Link, Message, Text} from 'dcme-style';
+
+```flow
+onChangeDOMCheckbox(event: HTMLEvent): void
+```
+
+This is designed for use with HTML checkboxes.
+It triggers a change that replaces the current value in the Parcel with the checked state of the checkbox.
+
+```js
+let parcel = new Parcel({
+    value: false
+});
+
+<input
+    type="checkbox"
+    value={parcel.value}
+    onChangeDOMCheckbox={parcel.onChangeDOMCheckbox}
+/>
+
+```
+
+<Box modifier="margin">
+    <Message>See also:
+        <Text element="div">- <Link href="#spreadDOMCheckbox">spreadDOMCheckbox</Link> for convenient spreading of value and onChange onto an input</Text>
+        <Text element="div">- <Link href="#onChangeDOM">onChangeDOM</Link> for use with input components that call `onChange` with a new value.</Text>
+    </Message>
+</Box>

--- a/packages/dataparcels-docs/src/docs/api/parcel/spread.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/spread.md
@@ -5,7 +5,7 @@ spread(notFoundValue: any): {value: *, onChange: OnChangeFunction}
 type OnChangeFunction = (value: any) => void;
 ```
 
-Returns an object with the Parcel's value and its onChange function.
+This is designed to bind a Parcel with an input component that expects a `value` and an `onChange` callback. The `onChange` callback is expected to pass an updated value as its first argument. 
 
 If `notFoundValue` is provided, and the Parcel's value is undefined or has been marked for deletion, the returned value will be equal to `notFoundValue`.
 

--- a/packages/dataparcels-docs/src/docs/api/parcel/spreadDOM.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/spreadDOM.md
@@ -5,7 +5,7 @@ spreadDOM(notFoundValue: any): {value: *, onChange: OnChangeDOMFunction}
 type OnChangeDOMFunction = (event: HTMLEvent) => void;
 ```
 
-Returns an object with the Parcel's value and its onChangeDOM function.
+This is designed to bind a Parcel with an HTML input. It returns an object with the Parcel's `value` and its `onChangeDOM` function.
 
 If `notFoundValue` is provided, and the Parcel's value is undefined or has been marked for deletion, the returned value will be equal to `notFoundValue`.
 

--- a/packages/dataparcels-docs/src/docs/api/parcel/spreadDOMCheckbox.md
+++ b/packages/dataparcels-docs/src/docs/api/parcel/spreadDOMCheckbox.md
@@ -1,0 +1,19 @@
+```flow
+spreadDOMCheckbox(): {value: *, onChange: OnChangeDOMCheckboxFunction}
+spreadDOMCheckbox(notFoundValue: boolean): {value: *, onChange: OnChangeDOMCheckboxFunction}
+
+type OnChangeDOMCheckboxFunction = (event: HTMLEvent) => void;
+```
+
+This is designed to bind a Parcel with an HTML checkbox.
+It returns an object with `checked` and `onChange`, where `checked` is the Parcel's `value` cast to a boolean, and `onChange` is the Parcel's `onChangeDOMCheckbox` function.
+
+If `notFoundValue` is provided, and the Parcel's value is undefined or has been marked for deletion, the returned value will be equal to `notFoundValue` cast to a boolean.
+
+```js
+let parcel = new Parcel({
+    value: 123
+});
+
+<input type="checkbox" {...parcel.spreadDOMCheckbox()} />
+```

--- a/packages/dataparcels-docs/src/examples/ParcelMetaSelections.jsx
+++ b/packages/dataparcels-docs/src/examples/ParcelMetaSelections.jsx
@@ -30,15 +30,9 @@ const FruitListEditor = (props) => {
             return <ParcelBoundary parcel={fruitParcel} key={fruitParcel.key}>
                 {(parcel) => {
                     let selectedParcel = parcel.metaAsParcel('selected');
-
-                    let checkboxProps = {
-                        checked: !!selectedParcel.value,
-                        onChange: (event) => selectedParcel.set(event.currentTarget.checked)
-                    };
-
                     return <div>
                         <input type="text" {...parcel.spreadDOM()} />
-                        <input type="checkbox" style={{width: '2rem'}} {...checkboxProps} />
+                        <input type="checkbox" style={{width: '2rem'}} {...selectedParcel.spreadDOMCheckbox()} />
                         <button onClick={() => parcel.swapPrev()}>^</button>
                         <button onClick={() => parcel.swapNext()}>v</button>
                         <button onClick={() => parcel.delete()}>x</button>

--- a/packages/dataparcels-docs/src/pages/api/Parcel.jsx
+++ b/packages/dataparcels-docs/src/pages/api/Parcel.jsx
@@ -12,6 +12,7 @@ import Markdown_id from 'docs/api/parcel/id.md';
 import Markdown_path from 'docs/api/parcel/path.md';
 import Markdown_spread from 'docs/api/parcel/spread.md';
 import Markdown_spreadDOM from 'docs/api/parcel/spreadDOM.md';
+import Markdown_spreadDOMCheckbox from 'docs/api/parcel/spreadDOMCheckbox.md';
 import Markdown_get from 'docs/api/parcel/get.md';
 import Markdown_getIn from 'docs/api/parcel/getIn.md';
 import Markdown_children from 'docs/api/parcel/children.md';
@@ -24,6 +25,7 @@ import Markdown_isFirst from 'docs/api/parcel/isFirst.md';
 import Markdown_isLast from 'docs/api/parcel/isLast.md';
 import Markdown_onChange from 'docs/api/parcel/onChange.md';
 import Markdown_onChangeDOM from 'docs/api/parcel/onChangeDOM.md';
+import Markdown_onChangeDOMCheckbox from 'docs/api/parcel/onChangeDOMCheckbox.md';
 import Markdown_set from 'docs/api/parcel/set.md';
 import Markdown_setIn from 'docs/api/parcel/setIn.md';
 import Markdown_update from 'docs/api/parcel/update.md';
@@ -67,6 +69,7 @@ const md = {
     path: Markdown_path,
     spread: Markdown_spread,
     spreadDOM: Markdown_spreadDOM,
+    spreadDOMCheckbox: Markdown_spreadDOMCheckbox,
     get: Markdown_get,
     getIn: Markdown_getIn,
     children: Markdown_children,
@@ -79,6 +82,7 @@ const md = {
     isLast: Markdown_isLast,
     onChange: Markdown_onChange,
     onChangeDOM: Markdown_onChangeDOM,
+    onChangeDOMCheckbox: Markdown_onChangeDOMCheckbox,
     set: Markdown_set,
     setIn: Markdown_setIn,
     update: Markdown_update,
@@ -132,8 +136,10 @@ metaAsParcel()
 # Input binding methods
 spread()
 spreadDOM()
+spreadDOMCheckbox()
 onChange()
 onChangeDOM()
+onChangeDOMCheckbox()
 
 # Child methods
 isFirst()

--- a/packages/dataparcels-docs/src/pages/ui-behaviour.md
+++ b/packages/dataparcels-docs/src/pages/ui-behaviour.md
@@ -329,15 +329,9 @@ const FruitListEditor = (props) => {
             return <ParcelBoundary parcel={fruitParcel} key={fruitParcel.key}>
                 {(parcel) => {
                     let selectedParcel = parcel.metaAsParcel('selected');
-                    
-                    let checkboxProps = {
-                        checked: !!selectedParcel.value,
-                        onChange: (event) => selectedParcel.set(event.currentTarget.checked)
-                    };
-
                     return <div>
                         <input type="text" {...parcel.spreadDOM()} />
-                        <input type="checkbox" style={{width: '2rem'}} {...checkboxProps} />
+                        <input type="checkbox" {...selectedParcel.spreadDOMCheckbox()} />
                         <button onClick={() => parcel.swapPrev()}>^</button>
                         <button onClick={() => parcel.swapNext()}>v</button>
                         <button onClick={() => parcel.delete()}>x</button>

--- a/packages/dataparcels/src/change/ChangeRequest.js
+++ b/packages/dataparcels/src/change/ChangeRequest.js
@@ -156,7 +156,7 @@ export default class ChangeRequest {
 
     hasValueChanged = (keyPath: Array<Key|Index> = []): boolean => {
         let {next, prev} = this.getDataIn(keyPath);
-        return next.value !== prev.value;
+        return !Object.is(next.value, prev.value);
     };
 
     toJS = (): Object => ({

--- a/packages/dataparcels/src/change/__test__/ChangeRequest-test.js
+++ b/packages/dataparcels/src/change/__test__/ChangeRequest-test.js
@@ -299,7 +299,8 @@ test('ChangeRequest hasValueChanged should indicate if value changed at path', (
                 c: [0,1],
                 d: 2
             },
-            b: 3
+            b: 3,
+            e: NaN
         }
     });
 
@@ -313,6 +314,7 @@ test('ChangeRequest hasValueChanged should indicate if value changed at path', (
     expect(basedChangeRequest.hasValueChanged(['a', 'd'])).toBe(false);
     expect(basedChangeRequest.hasValueChanged(['a'])).toBe(true);
     expect(basedChangeRequest.hasValueChanged(['b'])).toBe(false);
+    expect(basedChangeRequest.hasValueChanged(['e'])).toBe(false);
     expect(basedChangeRequest.hasValueChanged()).toBe(true);
 });
 

--- a/packages/dataparcels/src/parcel/Parcel.js
+++ b/packages/dataparcels/src/parcel/Parcel.js
@@ -293,6 +293,7 @@ export default class Parcel {
     // Spread methods
     spread = (notFoundValue: any = undefined): * => this._methods.spread(notFoundValue);
     spreadDOM = (notFoundValue: any = undefined): * => this._methods.spreadDOM(notFoundValue);
+    spreadDOMCheckbox = (notFoundValue: boolean = false): * => this._methods.spreadDOMCheckbox(notFoundValue);
 
     // Branch methods
     get = (key: Key|Index, notFoundValue: any = undefined): Parcel => this._methods.get(key, notFoundValue);
@@ -318,6 +319,7 @@ export default class Parcel {
     // Change methods
     onChange = (value: any) => this._methods.onChange(value);
     onChangeDOM = (event: *) => this._methods.onChangeDOM(event);
+    onChangeDOMCheckbox = (event: *) => this._methods.onChangeDOMCheckbox(event);
     set = overload({
         ["1"]: (value: any) => this._methods.setSelf(value),
         ["2"]: (key: Key|Index, value: any) => this._methods.set(key, value)

--- a/packages/dataparcels/src/parcel/__test__/ParcelChangeMethods-test.js
+++ b/packages/dataparcels/src/parcel/__test__/ParcelChangeMethods-test.js
@@ -222,6 +222,24 @@ test('Parcel.onChangeDOM() should work like onChange but take the value from eve
     });
 });
 
+test('Parcel.onChangeDOMCheckbox() should work like onChange but take the value from event.currentTarget.checked', () => {
+
+    let handleChange = jest.fn();
+
+    let parcel = new Parcel({
+        value: false,
+        handleChange
+    });
+
+    parcel.onChangeDOMCheckbox({
+        currentTarget: {
+            checked: true
+        }
+    });
+
+    expect(handleChange.mock.calls[0][0].value).toBe(true);
+});
+
 test('Parcel.setMeta() should call the Parcels handleChange function with the new meta merged in', () => {
     expect.assertions(3);
 

--- a/packages/dataparcels/src/parcel/__test__/ParcelGetMethods-test.js
+++ b/packages/dataparcels/src/parcel/__test__/ParcelGetMethods-test.js
@@ -78,6 +78,35 @@ test('Parcel.spreadDOM(notFoundValue) returns an object with notFoundValue', () 
     expect(parcel3.spreadDOM("???").value).toBe("123");
 });
 
+test('Parcel.spreadDOMCheckbox() returns an object with checked and onChange (onChangeDOMCheckbox)', () => {
+
+    var parcel = new Parcel({
+        value: true
+    });
+
+    const {
+        checked,
+        onChange
+    } = parcel.spreadDOMCheckbox();
+
+    expect(checked).toBe(parcel.value);
+    expect(onChange).toBe(parcel.onChangeDOMCheckbox);
+});
+
+test('Parcel.spreadDOMCheckbox(notFoundValue) returns an object with cast boolean / notFoundValue', () => {
+    var parcel = new Parcel({
+        value: undefined
+    });
+
+    var parcel3 = new Parcel({
+        value: "123"
+    });
+
+    expect(parcel.spreadDOMCheckbox().checked).toBe(false);
+    expect(parcel.spreadDOMCheckbox(true).checked).toBe(true);
+    expect(parcel.spreadDOMCheckbox(false).checked).toBe(false);
+});
+
 test('Parcel.log() should be called with parcel', () => {
 
     let {log} = console;

--- a/packages/dataparcels/src/parcel/methods/ParcelChangeMethods.js
+++ b/packages/dataparcels/src/parcel/methods/ParcelChangeMethods.js
@@ -82,6 +82,11 @@ export default (_this: Parcel) => ({
         _this.onChange(event.currentTarget.value);
     },
 
+    onChangeDOMCheckbox: (event: Object) => {
+        Types(`onChangeDOMCheckbox()`, `event`, `event`)(event);
+        _this.onChange(event.currentTarget.checked);
+    },
+
     setMeta: (partialMeta: ParcelMeta) => {
         Types(`setMeta()`, `partialMeta`, `object`)(partialMeta);
         _this.dispatch(ActionCreators.setMeta(partialMeta));

--- a/packages/dataparcels/src/parcel/methods/ParcelGetMethods.js
+++ b/packages/dataparcels/src/parcel/methods/ParcelGetMethods.js
@@ -31,6 +31,11 @@ export default (_this: Parcel) => ({
         onChange: _this.onChangeDOM
     }),
 
+    spreadDOMCheckbox: (notFoundValue: ?boolean = false): Object => ({
+        checked: !!getValue(_this, notFoundValue),
+        onChange: _this.onChangeDOMCheckbox
+    }),
+
     // Branch methods
 
     metaAsParcel: (key: string): Parcel => {


### PR DESCRIPTION
- add `Parcel.onChangeDOMCheckbox()`
- add `Parcel.spreadDOMCheckbox()`
- use `Object.is()` in `ChangeRequest.hasValueChanged()` so `NaN`s are accurately tested for equality