### PR TITLE
fix: .modifyDown() was not retaining child data

### DIFF
--- a/packages/dataparcels/src/parcel/__test__/ModifyMethods-test.js
+++ b/packages/dataparcels/src/parcel/__test__/ModifyMethods-test.js
@@ -29,6 +29,30 @@ test('Parcel.modifyDown() should return a new parcel with updated parcelData', (
     expect(updater.mock.calls[0][1]).toBe(undefined);
 });
 
+test('Parcel.modifyDown() should not destroy child data', () => {
+    let handleChange = jest.fn();
+    let updater = jest.fn(value => value + 1);
+
+    var parcel = new Parcel({
+        value: [123],
+        handleChange
+    })
+        .get(0)
+        .setMeta({def: 456});
+
+    let newParcel = handleChange.mock.calls[0][0].modifyDown(ii => ii);
+
+    expect(newParcel.data.child).toEqual([
+        {
+            key: '#a',
+            child: undefined,
+            meta: {
+                def: 456
+            }
+        }
+    ]);
+});
+
 test('Parcel.modifyDown() should allow non-parent types to be returned', () => {
     let updatedValue = new Parcel({
         value: 123

--- a/packages/dataparcels/src/parcelData/prepUpdater.js
+++ b/packages/dataparcels/src/parcelData/prepUpdater.js
@@ -3,7 +3,7 @@ import type {ParcelData} from '../types/Types';
 import type {ParcelValueUpdater} from '../types/Types';
 import type ChangeRequest from '../change/ChangeRequest';
 
-import setSelf from './setSelf';
+import setValue from './setValue';
 import shouldDangerouslyUpdateParcelData from './shouldDangerouslyUpdateParcelData';
 import ValidateValueUpdater from '../util/ValidateValueUpdater';
 
@@ -14,6 +14,6 @@ export default (updater: ParcelValueUpdater): Function => {
             let {value} = parcelData;
             let updatedValue = updater(value, changeRequest);
             ValidateValueUpdater(value, updatedValue);
-            return setSelf(updatedValue)(parcelData);
+            return setValue(updatedValue)(parcelData);
         };
 };

--- a/packages/dataparcels/src/parcelData/setSelf.js
+++ b/packages/dataparcels/src/parcelData/setSelf.js
@@ -1,21 +1,12 @@
 // @flow
 import type {ParcelDataEvaluator} from '../types/Types';
 
-import isParentValue from './isParentValue';
-import updateChild from './updateChild';
-import updateChildKeys from './updateChildKeys';
+import setValue from './setValue';
 
 import del from 'unmutable/lib/delete';
-import set from 'unmutable/lib/set';
-import pipeIf from 'unmutable/lib/util/pipeIf';
 import pipe from 'unmutable/lib/util/pipe';
 
 export default (value: *): ParcelDataEvaluator => pipe(
-    set('value', value),
     del('child'),
-    pipeIf(
-        () => isParentValue(value),
-        updateChild(),
-        updateChildKeys()
-    )
+    setValue(value)
 );

--- a/packages/dataparcels/src/parcelData/setValue.js
+++ b/packages/dataparcels/src/parcelData/setValue.js
@@ -1,0 +1,19 @@
+// @flow
+import type {ParcelDataEvaluator} from '../types/Types';
+
+import isParentValue from './isParentValue';
+import updateChild from './updateChild';
+import updateChildKeys from './updateChildKeys';
+
+import set from 'unmutable/lib/set';
+import pipeIf from 'unmutable/lib/util/pipeIf';
+import pipe from 'unmutable/lib/util/pipe';
+
+export default (value: *): ParcelDataEvaluator => pipe(
+    set('value', value),
+    pipeIf(
+        () => isParentValue(value),
+        updateChild(),
+        updateChildKeys()
+    )
+);


### PR DESCRIPTION
Originally done to be safe, modifyDown() was removing child data
so that the value returned from modifyDown()s updater and the existing
child data would be guaranteed to fit together. But given that
modifyDown() makes the end user (dev) promise not to change the shape,
then retaining child data is actually safe, as is more expected behaviour