### PR TITLE
add: validator rule meta

### DIFF
--- a/packages/dataparcels/src/validation/Validation.js
+++ b/packages/dataparcels/src/validation/Validation.js
@@ -14,7 +14,12 @@ import map from 'unmutable/map';
 import pipeWith from 'unmutable/pipeWith';
 import toArray from 'unmutable/toArray';
 
-type ValidationRule = (value: any, keyPath: Array<any>) => any;
+type ValidationRuleMeta = {
+    keyPath: Array<any>,
+    topLevelValue: any
+};
+
+type ValidationRule = (value: any, other: ValidationRuleMeta) => any;
 
 type ValidationRuleMap = {
     [matchPath: string]: ValidationRule|ValidationRule[]
@@ -27,6 +32,7 @@ type ValidationResult = {
 
 export default (validatorMap: ValidationRuleMap): ValidationResult => {
     let modifyBeforeUpdate = dangerouslyUpdateParcelData((parcelData) => {
+        let topLevelValue = parcelData.value;
         let allValid = true;
 
         let mapValidationRuleApplier = (validator: ValidationRule|ValidationRule[], path: string): ParcelDataEvaluator => {
@@ -40,7 +46,7 @@ export default (validatorMap: ValidationRuleMap): ValidationResult => {
                 (parcelData) => {
                     let invalid = []
                         .concat(validator)
-                        .reduce((invalid, validator) => invalid || validator(parcelData.value, keyPath), "");
+                        .reduce((invalid, validator) => invalid || validator(parcelData.value, {keyPath, topLevelValue}), "");
 
                     if(invalid) {
                         allValid = false;

--- a/packages/dataparcels/src/validation/__test__/Validation-test.js
+++ b/packages/dataparcels/src/validation/__test__/Validation-test.js
@@ -27,6 +27,11 @@ test('Validation should validate specified fields', () => {
 
     // validator should be called
     expect(isValid.mock.calls[0][0]).toBe(123);
+    expect(isValid.mock.calls[0][1].keyPath).toEqual(['abc']);
+    expect(isValid.mock.calls[0][1].topLevelValue).toEqual({
+        abc: 123,
+        def: 456
+    });
 
     // value should be untouched
     expect(newParcelData.value).toEqual(parcelData.value);


### PR DESCRIPTION
- Give validators on fields at any depth access to the top level value
- Does not count as a breaking change as this part of the API has not been documented ;)