### PR TITLE
react-dataparcels-drag hoc -> render props

### DIFF
--- a/packages/dataparcels-docs/src/content/API.js
+++ b/packages/dataparcels-docs/src/content/API.js
@@ -68,6 +68,7 @@ export default () => <Box>
     />
     <Text element="h3" modifier="marginKilo sizeKilo">See also</Text>
     <BulletList>
+        <BulletListItem><Link className="Link" to="/api/ParcelDrag">ParcelDrag</Link></BulletListItem>
         <BulletListItem><Link className="Link" to="/api/validation">validation</Link></BulletListItem>
         <BulletListItem><Link className="Link" to="/api/ChangeRequest">ChangeRequest</Link></BulletListItem>
         <BulletListItem><Link className="Link" to="/api/CancelActionMarker">CancelActionMarker</Link></BulletListItem>

--- a/packages/dataparcels-docs/src/examples/EditingArraysDrag.jsx
+++ b/packages/dataparcels-docs/src/examples/EditingArraysDrag.jsx
@@ -4,16 +4,6 @@ import ParcelBoundary from 'react-dataparcels/ParcelBoundary';
 import ParcelDrag from 'react-dataparcels-drag';
 import exampleFrame from 'component/exampleFrame';
 
-const SortableFruitList = ParcelDrag({
-    element: (fruitParcel) => <ParcelBoundary parcel={fruitParcel}>
-        {(parcel) => <div className="Box-draggable Typography">
-            <input type="text" {...parcel.spreadDOM()} />
-            <button onClick={() => parcel.insertAfter(`${parcel.value} copy`)}>+</button>
-            <button onClick={() => parcel.delete()}>x</button>
-        </div>}
-    </ParcelBoundary>
-});
-
 export default function FruitListEditor(props) {
 
     let [fruitListParcel] = useParcelState({
@@ -25,7 +15,15 @@ export default function FruitListEditor(props) {
     });
 
     return exampleFrame({fruitListParcel}, <div>
-        <SortableFruitList parcel={fruitListParcel} />
+        <ParcelDrag parcel={fruitListParcel}>
+            {(fruitParcel) => <ParcelBoundary parcel={fruitParcel}>
+                {(parcel) => <div className="Box-draggable Typography">
+                    <input type="text" {...parcel.spreadDOM()} />
+                    <button onClick={() => parcel.insertAfter(`${parcel.value} copy`)}>+</button>
+                    <button onClick={() => parcel.delete()}>x</button>
+                </div>}
+            </ParcelBoundary>}
+        </ParcelDrag>
         <button onClick={() => fruitListParcel.push("New fruit")}>Add new fruit</button>
     </div>);
 }

--- a/packages/dataparcels-docs/src/examples/EditingArraysDragSource.txt
+++ b/packages/dataparcels-docs/src/examples/EditingArraysDragSource.txt
@@ -3,16 +3,6 @@ import useParcelState from 'react-dataparcels/useParcelState';
 import ParcelBoundary from 'react-dataparcels/ParcelBoundary';
 import ParcelDrag from 'react-dataparcels-drag';
 
-const SortableFruitList = ParcelDrag({
-    element: (fruitParcel) => <ParcelBoundary parcel={fruitParcel}>
-        {(parcel) => <div>
-            <input type="text" {...parcel.spreadDOM()} />
-            <button onClick={() => parcel.insertAfter(`${parcel.value} copy`)}>+</button>
-            <button onClick={() => parcel.delete()}>x</button>
-        </div>}
-    </ParcelBoundary>
-});
-
 export default function FruitListEditor(props) {
 
     let [fruitListParcel] = useParcelState({
@@ -24,7 +14,15 @@ export default function FruitListEditor(props) {
     });
 
     return <div>
-        <SortableFruitList parcel={fruitListParcel} />
+        <ParcelDrag parcel={fruitListParcel}>
+            {(fruitParcel) => <ParcelBoundary parcel={fruitParcel}>
+                {(parcel) => <div>
+                    <input type="text" {...parcel.spreadDOM()} />
+                    <button onClick={() => parcel.insertAfter(`${parcel.value} copy`)}>+</button>
+                    <button onClick={() => parcel.delete()}>x</button>
+                </div>}
+            </ParcelBoundary>}
+        </ParcelDrag>
         <button onClick={() => fruitListParcel.push("New fruit")}>Add new fruit</button>
     </div>;
 }

--- a/packages/dataparcels-docs/src/pages/api/ParcelDrag.jsx
+++ b/packages/dataparcels-docs/src/pages/api/ParcelDrag.jsx
@@ -1,0 +1,20 @@
+// @flow
+import React from 'react';
+import Layout from 'layout/Layout';
+import ContentNav from 'shape/ContentNav';
+import DragMarkdown from 'pages/api/ParcelDrag.mdx';
+
+export default () => <Layout>
+    <ContentNav
+        content={() => <DragMarkdown />}
+        pageNav={[
+            '# ParcelDrag',
+            '# Children',
+            'childRenderer',
+            '# Props',
+            'parcel',
+            'container',
+            '...sortableElementProps'
+        ]}
+    />
+</Layout>;

--- a/packages/dataparcels-docs/src/pages/api/ParcelDrag.mdx
+++ b/packages/dataparcels-docs/src/pages/api/ParcelDrag.mdx
@@ -1,0 +1,63 @@
+import {Param} from 'dcme-style';
+import {Code} from 'dcme-style';
+import EditingArraysDragSource from 'examples/EditingArraysDragSource.txt';
+import {DocsSectionHeading} from 'dcme-style';
+
+# ParcelDrag
+
+```js
+import ParcelDrag from 'react-dataparcels-drag';
+```
+
+Dataparcels' drag plugin provides an easy way to add drag and drop sorting to arrays of items. It uses [react-sortable-hoc](https://github.com/clauderic/react-sortable-hoc) to perform the dragging and sorting, and all of `react-sortable-hoc`s API is accessible to use via ParcelDrag.
+
+### Example usage
+
+Please refer to the UI Behaviour page to see [a full example](/ui-behaviour/#Drag-and-drop-sorting).
+
+<Code language="jsx">{EditingArraysDragSource}</Code>
+
+## <DocsSectionHeading>Children</DocsSectionHeading>
+
+### childRenderer
+
+```flow
+(parcel: Parcel) => Node
+```
+ParcelDrag must be given a `childRenderer` function as children. This is called when rendering each child element, passing the Parcel for each element.
+
+* <Param name="parcel" type="Parcel" />
+  The Parcel for each element being rendered
+
+## <DocsSectionHeading>Props</DocsSectionHeading>
+
+### parcel
+
+```flow
+parcel: Parcel
+```
+
+The Parcel that will be sortable. This Parcel must be of type [IndexedParcel](/parcel-types#IndexedParcel), and an error will be thrown if it is not.
+
+### container
+
+```flow
+container: ComponentType<any> // optional, defaults to 'div'
+```
+
+The container element to render around the children. Defaults to `'div'`.
+
+<a id="sortableElementProps" />
+
+### ...sortableElementProps
+
+```flow
+...sortableElementProps: any
+```
+Any additional props will be passed onto [react-sortable-hoc's SortableContainer hoc](https://github.com/clauderic/react-sortable-hoc#sortableelement-hoc), to allow configuration of how the dragging behaves.
+
+Note that `SortableContainer`'s `onSortEnd` prop is not required, as it's provided by ParcelDrag. If you pass an `onSortEnd` prop to ParcelDrag, it will fire immediately after the Parcel triggers its change request.
+
+
+
+

--- a/packages/dataparcels-docs/src/pages/ui-behaviour.mdx
+++ b/packages/dataparcels-docs/src/pages/ui-behaviour.mdx
@@ -78,9 +78,7 @@ This example shows how to use meta stored against each element in an array to ke
 
 ## Drag and drop sorting
 
-Drag and drop is easy using [react-dataparcels-drag](https://www.npmjs.com/package/react-dataparcels-drag), which is a slim wrapper around [react-sortable-hoc](https://github.com/clauderic/react-sortable-hoc). Drag items up and down to change their order.
-
-The `react-dataparcels-drag` hoc attempts to keep a very similar API to `react-sortable-hoc`, and therefore its usage is a little different compared to the other hocs in `react-dataparcels`.
+Drag and drop is easy using [react-dataparcels-drag](https://www.npmjs.com/package/react-dataparcels-drag), which uses [react-sortable-hoc](https://github.com/clauderic/react-sortable-hoc). Drag items up and down to change their order.
 
 <EditingArraysDrag />
 <Code language="jsx">{EditingArraysDragSource}</Code>

--- a/packages/dataparcels-docs/src/shape/ContentNav.jsx
+++ b/packages/dataparcels-docs/src/shape/ContentNav.jsx
@@ -19,6 +19,7 @@ const nav = () => <NavigationList>
     <NavigationListItem><Link to="/api/useParcelForm">useParcelForm</Link></NavigationListItem>
     <NavigationListItem><Link to="/api/useParcelBuffer">useParcelBuffer</Link></NavigationListItem>
     <NavigationListItem><Link to="/api/validation">validation</Link></NavigationListItem>
+    <NavigationListItem><Link to="/api/ParcelDrag">ParcelDrag</Link></NavigationListItem>
     <NavigationListItem><Link to="/api">more...</Link></NavigationListItem>
     <NavigationListItem modifier="section">Concepts</NavigationListItem>
     <NavigationListItem><Link to="/parcel-keys">Parcel keys</Link></NavigationListItem>

--- a/packages/dataparcels-docs/yalc.lock
+++ b/packages/dataparcels-docs/yalc.lock
@@ -7,7 +7,7 @@
       "replaced": "^0.19.0"
     },
     "react-dataparcels-drag": {
-      "signature": "ed702c0fe6b9c055088edae4dda0b40e",
+      "signature": "8c1a8220c9d15d152dd1081668640800",
       "file": true,
       "replaced": "^0.18.1"
     }

--- a/packages/dataparcels-docs/yalc.lock
+++ b/packages/dataparcels-docs/yalc.lock
@@ -1,4 +1,15 @@
 {
   "version": "v1",
-  "packages": {}
+  "packages": {
+    "react-dataparcels": {
+      "signature": "bf3cf47614ad794dc36c0c80634205f1",
+      "file": true,
+      "replaced": "^0.21.0"
+    },
+    "react-dataparcels-drag": {
+      "signature": "415240e94e3a264282965023f77a2fbb",
+      "file": true,
+      "replaced": "^0.21.0"
+    }
+  }
 }

--- a/packages/dataparcels-docs/yarn.lock
+++ b/packages/dataparcels-docs/yarn.lock
@@ -3597,10 +3597,10 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
-dataparcels@^0.21.0-alpha.0:
-  version "0.21.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/dataparcels/-/dataparcels-0.21.0-alpha.0.tgz#14c5e0e74eb20834c8e7957fd6484575ba18c38d"
-  integrity sha512-eP4/qMP/2b1T1Rw0jWJwq8I0rDJkidhKP+f66rYMNoYA+W4YP+tooYfPDozAnivP8HMKtpyCY1ael50LPidLpQ==
+dataparcels@^0.21.0:
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/dataparcels/-/dataparcels-0.21.0.tgz#c0c27a8a7f4850e1c792301eda7c4c4b505a442e"
+  integrity sha512-yLeQxOX8RzbCMfN4fDO4m++nr0mj/2cwXcERMoZYK+Yi/bsXHXGgxEmvfCxZMMrfZsFf3dBfXKGYPL/u6ZiYqw==
   dependencies:
     "@babel/runtime" "^7.1.5"
     unmutable "^0.41.1"
@@ -9688,16 +9688,16 @@ react-cool-storage@^0.1.1:
     unmutable "^0.39.0"
 
 "react-dataparcels-drag@file:.yalc/react-dataparcels-drag":
-  version "0.21.0-alpha.0-ed702c0f"
+  version "0.21.0-fc7aaf63"
   dependencies:
     "@babel/runtime" "^7.1.5"
     react-sortable-hoc "1.4.0"
 
 "react-dataparcels@file:.yalc/react-dataparcels":
-  version "0.21.0-alpha.0-9200b2ef"
+  version "0.21.0-f46cdd75"
   dependencies:
     "@babel/runtime" "^7.1.5"
-    dataparcels "^0.21.0-alpha.0"
+    dataparcels "^0.21.0"
     unmutable "^0.41.1"
     use-debounce "^1.1.3"
 

--- a/packages/react-dataparcels-drag/src/Drag.js
+++ b/packages/react-dataparcels-drag/src/Drag.js
@@ -8,19 +8,20 @@ import React from 'react';
 import {SortableContainer} from 'react-sortable-hoc';
 import {SortableElement} from 'react-sortable-hoc';
 
-type Config = {
-    element: (parcel: Parcel, rest: *) => Node,
+type Props = {
+    children: (parcel: Parcel) => Node,
+    parcel: Parcel,
+    onSortEnd?: ({oldIndex: number, newIndex: number}) => void,
     container?: ComponentType<*>
 };
 
-type Props = {
-    parcel: Parcel,
-    onSortEnd?: ({oldIndex: number, newIndex: number}) => void
-};
+export default ({children, parcel, onSortEnd, container, ...sortableElementProps}: Props) => {
+    if(!parcel.isIndexed()) {
+        throw new Error(`react-dataparcels-drag's parcel prop must be of type indexed`);
+    }
 
-export default ({element, container, ...configRest}: Config) => {
     let Container = container || 'div';
-    let ConfiguredElement = SortableElement(({parcel, ...rest}) => element(parcel, rest));
+    let ConfiguredElement = SortableElement(({parcel}) => children(parcel));
     let ConfiguredContainer = SortableContainer(({parcel}) => <Container>
         {parcel.toArray((elementParcel, index) => <ConfiguredElement
             key={elementParcel.key}
@@ -29,19 +30,13 @@ export default ({element, container, ...configRest}: Config) => {
         />)}
     </Container>);
 
-    return ({parcel, onSortEnd, ...rest}: Props): Node => {
-        if(!parcel.isIndexed()) {
-            throw new Error(`react-dataparcels-drag's parcel prop must be of type indexed`);
-        }
-        return <ConfiguredContainer
-            parcel={parcel}
-            onSortEnd={(param) => {
-                let {oldIndex, newIndex} = param;
-                parcel.move(oldIndex, newIndex);
-                onSortEnd && onSortEnd(param);
-            }}
-            {...configRest}
-            {...rest}
-        />;
-    };
+    return <ConfiguredContainer
+        parcel={parcel}
+        onSortEnd={(param) => {
+            let {oldIndex, newIndex} = param;
+            parcel.move(oldIndex, newIndex);
+            onSortEnd && onSortEnd(param);
+        }}
+        {...sortableElementProps}
+    />;
 };

--- a/packages/react-dataparcels-drag/src/__test__/Drag-test.js
+++ b/packages/react-dataparcels-drag/src/__test__/Drag-test.js
@@ -1,6 +1,6 @@
 // // @flow
 import React from 'react';
-import Parcel from 'react-dataparcels';
+import Parcel from 'dataparcels';
 import Drag from '../Drag';
 
 test('Drag must pass props correctly', () => {
@@ -12,12 +12,8 @@ test('Drag must pass props correctly', () => {
         handleChange
     });
 
-    let MyDrag = Drag({
-        element: () => <div />
-    });
-
     // $FlowFixMe
-    let wrapper = shallow(<MyDrag parcel={parcel} />, {disableLifecycleMethods: true});
+    let wrapper = shallow(<Drag parcel={parcel} children={() => <div />} />, {disableLifecycleMethods: true});
 
     // first level in
     let props1 = wrapper.props();
@@ -40,13 +36,9 @@ test('Drag should throw if parcel is not indexed', () => {
         value: {abc: 123}
     });
 
-    let MyDrag = Drag({
-        element: () => <div />
-    });
-
     expect(() => {
         // $FlowFixMe
-        shallow(<MyDrag parcel={parcel} />, {disableLifecycleMethods: true});
+        shallow(<Drag parcel={parcel} children={() => <div />} />, {disableLifecycleMethods: true});
     }).toThrow(`react-dataparcels-drag's parcel prop must be of type indexed`);
 });
 
@@ -59,14 +51,10 @@ test('Drag must accept onSortEnd and still call internal onSortEnd', () => {
         handleChange
     });
 
-    let MyDrag = Drag({
-        element: () => <div />
-    });
-
     let onSortEnd = jest.fn();
 
     // $FlowFixMe
-    let wrapper = shallow(<MyDrag parcel={parcel} onSortEnd={onSortEnd} />, {disableLifecycleMethods: true});
+    let wrapper = shallow(<Drag parcel={parcel} onSortEnd={onSortEnd} children={() => <div />} />, {disableLifecycleMethods: true});
 
     let props = wrapper.props();
     let sortEndArg = {oldIndex: 0, newIndex: 2};
@@ -84,51 +72,11 @@ test('Drag must accept additional props and pass them to react-sortable-hoc as p
         value: [1,2,3]
     });
 
-    let MyDrag = Drag({
-        element: () => <div />
-    });
-
     // $FlowFixMe
-    let wrapper = shallow(<MyDrag parcel={parcel} woo={123} />, {disableLifecycleMethods: true});
+    let wrapper = shallow(<Drag parcel={parcel} woo={123} children={() => <div />} />, {disableLifecycleMethods: true});
 
     let props = wrapper.props();
     expect(props.woo).toBe(123);
-});
-
-test('Drag must accept additional config and pass them to react-sortable-hoc as props', () => {
-
-    let parcel = new Parcel({
-        value: [1,2,3]
-    });
-
-    let MyDrag = Drag({
-        element: () => <div />,
-        woo: 123
-    });
-
-    // $FlowFixMe
-    let wrapper = shallow(<MyDrag parcel={parcel} />, {disableLifecycleMethods: true});
-
-    let props = wrapper.props();
-    expect(props.woo).toBe(123);
-});
-
-test('Drag must prefer props over config', () => {
-
-    let parcel = new Parcel({
-        value: [1,2,3]
-    });
-
-    let MyDrag = Drag({
-        element: () => <div />,
-        woo: 123
-    });
-
-    // $FlowFixMe
-    let wrapper = shallow(<MyDrag parcel={parcel} woo={456} />, {disableLifecycleMethods: true});
-
-    let props = wrapper.props();
-    expect(props.woo).toBe(456);
 });
 
 test('Drag must render elements and pass parcels to them', () => {
@@ -139,13 +87,9 @@ test('Drag must render elements and pass parcels to them', () => {
         value
     });
 
-    let element = jest.fn(() => <div />);
-
-    let MyDrag = Drag({
-        element
-    });
+    let children = jest.fn(() => <div />);
 
     // $FlowFixMe
-    let wrapper = mount(<MyDrag parcel={parcel} />);
-    expect(element.mock.calls.map(call => call[0].value)).toEqual([1,2,3]);
+    let wrapper = mount(<Drag parcel={parcel} children={children} />);
+    expect(children.mock.calls.map(call => call[0].value)).toEqual([1,2,3]);
 });


### PR DESCRIPTION
Addresses #182 #214 

## react-dataparcels-drag

- **BREAKING CHANGE** `react-dataparcels-drag` is used as a render props component rather than as a hoc. See docs for details on how to upgrade.