### PR TITLE
Async onChange + revertable changes

### DIFF
--- a/packages/dataparcels-docs/src/examples/SubmitButtonOnChange.jsx
+++ b/packages/dataparcels-docs/src/examples/SubmitButtonOnChange.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import {useRef} from 'react';
+import {useState} from 'react';
+import useParcelForm from 'react-dataparcels/useParcelForm';
+import ParcelBoundary from 'react-dataparcels/ParcelBoundary';
+import exampleFrame from 'component/exampleFrame';
+
+const initialValue = {
+    firstname: "",
+    lastname: ""
+};
+
+export default function SignUpForm(props) {
+
+    let [requestState, setRequestState] = useState("idle");
+    let rejectRef = useRef(() => {});
+
+    let saveMyData = () => new Promise((resolve, reject) => {
+        setRequestState("pending...");
+
+        let timeout = setTimeout(() => {
+            setRequestState("resolved");
+            resolve();
+        }, 2000);
+
+        rejectRef.current = () => {
+            setRequestState("rejected");
+            clearTimeout(timeout);
+            reject();
+        };
+    });
+
+    let [personParcel, personParcelBuffer] = useParcelForm({
+        value: initialValue,
+        onChange: (parcel) => saveMyData(parcel.value)
+        // ^ returns a promise
+    });
+
+    let personParcelState = personParcelBuffer._outerParcel;
+    return exampleFrame({personParcelState, personParcel}, <div>
+        <label>firstname</label>
+        <ParcelBoundary parcel={personParcel.get('firstname')}>
+            {(firstname) => <input type="text" {...firstname.spreadDOM()} />}
+        </ParcelBoundary>
+
+        <label>lastname</label>
+        <ParcelBoundary parcel={personParcel.get('lastname')}>
+            {(lastname) => <input type="text" {...lastname.spreadDOM()} />}
+        </ParcelBoundary>
+
+        <button onClick={() => personParcelBuffer.submit()}>Submit</button>
+
+        <p>Request state: <strong>{requestState}</strong>
+            {requestState === "pending..." && <button onClick={rejectRef.current}>reject</button>}
+        </p>
+    </div>);
+}

--- a/packages/dataparcels-docs/src/examples/SubmitButtonOnChangeClear.jsx
+++ b/packages/dataparcels-docs/src/examples/SubmitButtonOnChangeClear.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import {useRef} from 'react';
+import {useState} from 'react';
+import useParcelForm from 'react-dataparcels/useParcelForm';
+import ParcelBoundary from 'react-dataparcels/ParcelBoundary';
+import exampleFrame from 'component/exampleFrame';
+
+const initialValue = {
+    firstname: "",
+    lastname: ""
+};
+
+export default function SignUpForm(props) {
+
+    let [requestState, setRequestState] = useState("idle");
+    let rejectRef = useRef(() => {});
+
+    let saveMyData = () => new Promise((resolve, reject) => {
+        setRequestState("pending...");
+
+        let timeout = setTimeout(() => {
+            setRequestState("resolved");
+            resolve();
+        }, 2000);
+
+        rejectRef.current = () => {
+            setRequestState("rejected");
+            clearTimeout(timeout);
+            reject();
+        };
+    });
+
+    let [personParcel, personParcelBuffer] = useParcelForm({
+        value: initialValue,
+        onChange: async (parcel) => {
+            await saveMyData(parcel.value);
+            return initialValue;
+        },
+        onChangeUseResult: true
+    });
+
+    let personParcelState = personParcelBuffer._outerParcel;
+    return exampleFrame({personParcelState, personParcel}, <div>
+        <label>firstname</label>
+        <ParcelBoundary parcel={personParcel.get('firstname')}>
+            {(firstname) => <input type="text" {...firstname.spreadDOM()} />}
+        </ParcelBoundary>
+
+        <label>lastname</label>
+        <ParcelBoundary parcel={personParcel.get('lastname')}>
+            {(lastname) => <input type="text" {...lastname.spreadDOM()} />}
+        </ParcelBoundary>
+
+        <button onClick={() => personParcelBuffer.submit()}>Submit</button>
+
+        <p>Request state: <strong>{requestState}</strong>
+            {requestState === "pending..." && <button onClick={rejectRef.current}>reject</button>}
+        </p>
+    </div>);
+}

--- a/packages/dataparcels-docs/src/examples/SubmitButtonOnChangeClearSource.txt
+++ b/packages/dataparcels-docs/src/examples/SubmitButtonOnChangeClearSource.txt
@@ -1,0 +1,34 @@
+import React from 'react';
+import useParcelForm from 'react-dataparcels/useParcelForm';
+import ParcelBoundary from 'react-dataparcels/ParcelBoundary';
+
+const initialValue = {
+    firstname: "",
+    lastname: ""
+};
+
+export default function SignUpForm(props) {
+
+    let [personParcel, personParcelBuffer] = useParcelForm({
+        value: initialValue,
+        onChange: async (parcel) => {
+            await saveMyData(parcel.value);
+            return initialValue;
+        },
+        onChangeUseResult: true
+    });
+
+    return <div>
+        <label>firstname</label>
+        <ParcelBoundary parcel={personParcel.get('firstname')}>
+            {(firstname) => <input type="text" {...firstname.spreadDOM()} />}
+        </ParcelBoundary>
+
+        <label>lastname</label>
+        <ParcelBoundary parcel={personParcel.get('lastname')}>
+            {(lastname) => <input type="text" {...lastname.spreadDOM()} />}
+        </ParcelBoundary>
+
+        <button onClick={() => personParcelBuffer.submit()}>Submit</button>
+    </div>;
+}

--- a/packages/dataparcels-docs/src/examples/SubmitButtonOnChangeLoad.jsx
+++ b/packages/dataparcels-docs/src/examples/SubmitButtonOnChangeLoad.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import {useRef} from 'react';
+import {useState} from 'react';
+import useParcelForm from 'react-dataparcels/useParcelForm';
+import ParcelBoundary from 'react-dataparcels/ParcelBoundary';
+import exampleFrame from 'component/exampleFrame';
+
+const initialValue = {
+    firstname: "",
+    lastname: "",
+    timeUpdated: undefined
+};
+
+export default function PersonEditor(props) {
+
+    let [requestState, setRequestState] = useState("idle");
+    let rejectRef = useRef(() => {});
+
+    let saveMyData = ({firstname, lastname}) => new Promise((resolve, reject) => {
+        setRequestState("pending...");
+
+        let timeout = setTimeout(() => {
+            setRequestState("resolved");
+            resolve({
+                firstname: firstname.toLowerCase(),
+                lastname: lastname.toLowerCase(),
+                timeUpdated: new Date()
+            });
+        }, 2000);
+
+        rejectRef.current = () => {
+            setRequestState("rejected");
+            clearTimeout(timeout);
+            reject();
+        };
+    });
+
+    let [personParcel, personParcelBuffer] = useParcelForm({
+        value: initialValue,
+        onChange: (parcel) => saveMyData(parcel.value),
+        onChangeUseResult: true
+    });
+
+    let {timeUpdated} = personParcel.value;
+
+    let personParcelState = personParcelBuffer._outerParcel;
+    return exampleFrame({personParcelState, personParcel}, <div>
+        <label>firstname</label>
+        <ParcelBoundary parcel={personParcel.get('firstname')}>
+            {(firstname) => <input type="text" {...firstname.spreadDOM()} />}
+        </ParcelBoundary>
+
+        <label>lastname</label>
+        <ParcelBoundary parcel={personParcel.get('lastname')}>
+            {(lastname) => <input type="text" {...lastname.spreadDOM()} />}
+        </ParcelBoundary>
+
+        <p>Time updated: {timeUpdated && timeUpdated.toLocaleString()}</p>
+
+        <button onClick={() => personParcelBuffer.submit()}>Submit</button>
+
+        <p>Request state: <strong>{requestState}</strong>
+            {requestState === "pending..." && <button onClick={rejectRef.current}>reject</button>}
+        </p>
+    </div>);
+}

--- a/packages/dataparcels-docs/src/examples/SubmitButtonOnChangeLoadSource.txt
+++ b/packages/dataparcels-docs/src/examples/SubmitButtonOnChangeLoadSource.txt
@@ -1,0 +1,30 @@
+import React from 'react';
+import useParcelForm from 'react-dataparcels/useParcelForm';
+import ParcelBoundary from 'react-dataparcels/ParcelBoundary';
+
+export default function PersonEditor(props) {
+
+    let [personParcel, personParcelBuffer] = useParcelForm({
+        value: props.valueLoadedFromServer,
+        onChange: (parcel) => saveMyData(parcel.value),
+        onChangeUseResult: true
+    });
+
+    let {timeUpdated} = personParcel.value;
+
+    return <div>
+        <label>firstname</label>
+        <ParcelBoundary parcel={personParcel.get('firstname')}>
+            {(firstname) => <input type="text" {...firstname.spreadDOM()} />}
+        </ParcelBoundary>
+
+        <label>lastname</label>
+        <ParcelBoundary parcel={personParcel.get('lastname')}>
+            {(lastname) => <input type="text" {...lastname.spreadDOM()} />}
+        </ParcelBoundary>
+
+        <p>Time updated: {timeUpdated.toLocaleString()}</p>
+
+        <button onClick={() => personParcelBuffer.submit()}>Submit</button>
+    </div>;
+}

--- a/packages/dataparcels-docs/src/examples/SubmitButtonOnChangeReduxSource.txt
+++ b/packages/dataparcels-docs/src/examples/SubmitButtonOnChangeReduxSource.txt
@@ -1,0 +1,36 @@
+import React from 'react';
+import useParcelForm from 'react-dataparcels/useParcelForm';
+import ParcelBoundary from 'react-dataparcels/ParcelBoundary';
+
+export default function PersonEditor(props) {
+
+    let [personParcel, personParcelBuffer] = useParcelForm({
+        value: props.personData,
+        updateValue: true,
+        onChange: (parcel) => props.dispatchMySaveAction(parcel.value)
+    });
+
+    // ^ dispatchMySaveAction should return a promise if it is
+    // to work correctly with useParcelForm
+    // The return value doesn't matter,
+    // useParcelForm just wants to know
+    // if the request succeeded or not
+
+    let {timeUpdated} = personParcel.value;
+
+    return <div>
+        <label>firstname</label>
+        <ParcelBoundary parcel={personParcel.get('firstname')}>
+            {(firstname) => <input type="text" {...firstname.spreadDOM()} />}
+        </ParcelBoundary>
+
+        <label>lastname</label>
+        <ParcelBoundary parcel={personParcel.get('lastname')}>
+            {(lastname) => <input type="text" {...lastname.spreadDOM()} />}
+        </ParcelBoundary>
+
+        <p>Time updated: {timeUpdated.toLocaleString()}</p>
+
+        <button onClick={() => personParcelBuffer.submit()}>Submit</button>
+    </div>;
+}

--- a/packages/dataparcels-docs/src/examples/SubmitButtonOnChangeSource.txt
+++ b/packages/dataparcels-docs/src/examples/SubmitButtonOnChangeSource.txt
@@ -1,0 +1,31 @@
+import React from 'react';
+import useParcelForm from 'react-dataparcels/useParcelForm';
+import ParcelBoundary from 'react-dataparcels/ParcelBoundary';
+
+const initialValue = {
+    firstname: "",
+    lastname: ""
+};
+
+export default function SignUpForm(props) {
+
+    let [personParcel, personParcelBuffer] = useParcelForm({
+        value: initialValue,
+        onChange: (parcel) => saveMyData(parcel.value)
+        // ^ returns a promise
+    });
+
+    return <div>
+        <label>firstname</label>
+        <ParcelBoundary parcel={personParcel.get('firstname')}>
+            {(firstname) => <input type="text" {...firstname.spreadDOM()} />}
+        </ParcelBoundary>
+
+        <label>lastname</label>
+        <ParcelBoundary parcel={personParcel.get('lastname')}>
+            {(lastname) => <input type="text" {...lastname.spreadDOM()} />}
+        </ParcelBoundary>
+
+        <button onClick={() => personParcelBuffer.submit()}>Submit</button>
+    </div>;
+}

--- a/packages/dataparcels-docs/src/pages/api/useParcelForm.jsx
+++ b/packages/dataparcels-docs/src/pages/api/useParcelForm.jsx
@@ -13,6 +13,7 @@ export default () => <Layout>
             'value',
             'updateValue',
             'onChange',
+            'onChangeUseResult',
             'buffer',
             'debounce',
             'validation',

--- a/packages/dataparcels-docs/src/pages/api/useParcelForm.mdx
+++ b/packages/dataparcels-docs/src/pages/api/useParcelForm.mdx
@@ -146,8 +146,10 @@ If provided, this function is called after innerParcel releases the contents of 
 
 It's possible to return a promise from `onChange`. When doing this, the ChangeRequest's propagation is halted and is only released once the promise resolves, at which point outerParcel's state will be updated to contain the new Parcel.
 
-If another change arrives while a promise is pending, it will be passed through `onChange` after the first promise is resolved or rejected. This is to ensure that there is only one operation happening at a time. If the first ChangeRequest's promise is rejected, the changes will be merged with the next ChangeRequest when `onChange` is called the second time.
+If another change arrives while a promise is pending, it will be passed through `onChange` after the first promise is resolved or rejected. This is to ensure that there is only one operation happening at a time. If the first ChangeRequest's
+promise is rejected, the changes will be merged with the next ChangeRequest when `onChange` is called the second time.
 
+This is discussed in more detail in [data synchronisation](/data-synchronisation).
 
 ```js
 let [parcel] = useParcelForm({
@@ -168,7 +170,7 @@ onChangeUseResult?: boolean = false // optional
 
 When true, this sets the value of the outerParcel to the return value of `onChange`. If `onChange` returns a promise, the resolved value of the promise will be used.
 
-Using `onChangeUseResult` can be useful for receiving data back from a request to write data to a server, as it ensures that outerParcel's value is as up-to-date as possible. This is discussed in more detail in [data synchronisation](/data-synchronisation).
+Using `onChangeUseResult` can be useful for receiving data back from a request to write data to a server, as it ensures that outerParcel's value is as up-to-date as possible. This is discussed in more detail in [data synchronisation](/data-synchronisation#Receiving-data-from-the-server-after-saving).
 
 ```js
 let [parcel] = useParcelForm({

--- a/packages/dataparcels-docs/src/pages/api/useParcelForm.mdx
+++ b/packages/dataparcels-docs/src/pages/api/useParcelForm.mdx
@@ -28,9 +28,10 @@ The hook looks roughly like this:
 // and sends changed data to a callback
 let [outerParcel] = useParcelState({
     value,
-    updateValue,
-    onChange // e.g. (parcel) => saveMyData(parcel.value)
+    updateValue
 });
+
+// ...some magic related to the onChange function...
 
 // 2. Parcel Buffer
 //
@@ -63,6 +64,7 @@ let [parcel] = useParcelForm({
     // optional
     updateValue?: boolean,
     onChange?: Function,
+    onChangeUseResult?: boolean,
     buffer?: boolean,
     debounce?: number,
     validation?: Function,
@@ -137,14 +139,15 @@ parcel.set(200);
 ### onChange
 
 ```flow
-onChange?: (parcel: Parcel, changeRequest: ChangeRequest) => void // optional
+onChange?: (parcel: Parcel, changeRequest: ChangeRequest) => any|Promise<any> // optional
 ```
 
-If provided, this function is called whenever useParcelForm's Parcel has handled a change. It receives the new [Parcel](/api/Parcel), and the [ChangeRequest](/api/ChangeRequest) that was responsible for the change.
+If provided, this function is called after innerParcel releases the contents of its buffer and propagates its changes, but before outerParcel's state is updated. It receives the new [Parcel](/api/Parcel), and the [ChangeRequest](/api/ChangeRequest) that was responsible for the change. This function can be used to relay changes further up the React heirarchy.
 
-This function can be used to relay changes further up the React heirarchy.
+It's possible to return a promise from `onChange`. When doing this, the ChangeRequest's propagation is halted and is only released once the promise resolves, at which point outerParcel's state will be updated to contain the new Parcel.
 
-Please keep in mind that it is possible for a change to result in the same data being contained in the Parcel, `onChange` will not dedupe subsequent calls whose Parcels contain the same data.
+If another change arrives while a promise is pending, it will be passed through `onChange` after the first promise is resolved or rejected. This is to ensure that there is only one operation happening at a time. If the first ChangeRequest's promise is rejected, the changes will be merged with the next ChangeRequest when `onChange` is called the second time.
+
 
 ```js
 let [parcel] = useParcelForm({
@@ -152,6 +155,30 @@ let [parcel] = useParcelForm({
     onChange: (parcel, changeRequest) => {
         // add logic here
     }
+});
+```
+
+*Please keep in mind that it is possible for a change to result in the same data being contained in the Parcel, `onChange` will not dedupe subsequent calls whose Parcels contain the same data.*
+
+### onChangeUseResult
+
+```flow
+onChangeUseResult?: boolean = false // optional
+```
+
+When true, this sets the value of the outerParcel to the return value of `onChange`. If `onChange` returns a promise, the resolved value of the promise will be used.
+
+Using `onChangeUseResult` can be useful for receiving data back from a request to write data to a server, as it ensures that outerParcel's value is as up-to-date as possible. This is discussed in more detail in [data synchronisation](/data-synchronisation).
+
+```js
+let [parcel] = useParcelForm({
+    value: receivedValue,
+    onChange: (parcel, changeRequest) => {
+        return saveMyData(parcel.value);
+        // ^ saveMyData send a request to a server to save the data,
+        // and returns a promise containing the updated data from the server
+    },
+    onChangeUseResult: true
 });
 ```
 
@@ -163,7 +190,7 @@ buffer?: boolean = true // optional
 
 When `buffer` is true, changes that occur to `parcel` will be caught in useParcelForm's buffer, until released explicitly by calling [parcelBuffer.submit()](#submit), or automatically if [debounce](#debounce) is being used.
 
-When `buffer` is false, changes will propagate up to the top Parcel in useParcelForm's state immediately.
+When `buffer` is false, changes will propagate up to useParcelForm's outerParcel immediately.
 
 ### debounce
 
@@ -177,7 +204,7 @@ This can be used to make [autosaving forms](/ui-behaviour#Autosaving-forms).
 
 #### Debouncing explained
 
-When the `parcel` sends a change, the useParelForm hook will catch it and prevent it from being propagated up to the main Parcel that it holds in state.
+When the `parcel` sends a change, the useParelForm hook will catch it and prevent it from being propagated up to useParcelForm's outerParcel.
 
 The useParcelForm hooks waits until no new changes have occured for `debounce` number of milliseconds. It then releases all the changes it has buffered, all together in a single change request.
 
@@ -273,7 +300,7 @@ parcel.set("HELLO");
 parcel: Parcel
 ```
 
-The first element of the returned array is the `parcel`, a Parcel that contains the current state of `parcel` with all the changes in the buffer applied to it. When buffering is enabled, any changes that `parcel` receives will go into the buffer.
+The first element of the returned array is the parcel previously referred to as innerParcel. It's a Parcel that contains the current state of outerParcel, with all the changes in the buffer applied to it. When buffering is enabled, any changes that `parcel` receives will go into the buffer.
 
 ### parcelBuffer
 

--- a/packages/dataparcels-docs/src/pages/data-synchronisation.js
+++ b/packages/dataparcels-docs/src/pages/data-synchronisation.js
@@ -10,7 +10,8 @@ export default () => <Layout>
         pageNav={[
             '# Data synchronisation',
             'Saving data from a form',
-            'Changing or clearing form data after save'
+            'Clearing a form after submit',
+            'Receiving data from the server after saving'
         ]}
     />
 </Layout>;

--- a/packages/dataparcels-docs/src/pages/data-synchronisation.js
+++ b/packages/dataparcels-docs/src/pages/data-synchronisation.js
@@ -9,7 +9,8 @@ export default () => <Layout>
         content={() => <DataSynchronisationMarkdown />}
         pageNav={[
             '# Data synchronisation',
-            'Saving data from a form'
+            'Saving data from a form',
+            'Changing or clearing form data after save'
         ]}
     />
 </Layout>;

--- a/packages/dataparcels-docs/src/pages/data-synchronisation.js
+++ b/packages/dataparcels-docs/src/pages/data-synchronisation.js
@@ -8,7 +8,8 @@ export default () => <Layout>
     <ContentNav
         content={() => <DataSynchronisationMarkdown />}
         pageNav={[
-            '# Data synchronisation'
+            '# Data synchronisation',
+            'Saving data from a form'
         ]}
     />
 </Layout>;

--- a/packages/dataparcels-docs/src/pages/data-synchronisation.mdx
+++ b/packages/dataparcels-docs/src/pages/data-synchronisation.mdx
@@ -1,41 +1,18 @@
 import Link from 'gatsby-link';
+import {Code} from 'dcme-style';
 import {Divider} from 'dcme-style';
+import SubmitButtonOnChange from 'examples/SubmitButtonOnChange';
+import SubmitButtonOnChangeSource from 'examples/SubmitButtonOnChangeSource.txt';
 
 # Data synchronisation
 
 Data synchronisation encompasses how dataparcels interacts with pieces of data stored externally.
 
-## Parcel as a slave
+**This part of the library is being developed and will be complete soon.**
 
-* 👍 Necessary features complete
-* 🚧 Example under construction
+## Saving data from a form
 
-<Divider />
+The simplest type of data synchronisation is a typical web form that can be submitted. Typical forms are often initially blank, or may occasionally preload some data from a server. Once the form is presented to the user it is the master of its own state. The data flow from this point on is unidirectional e.g. the form sends data to the server, and the server never pushes data back into the form.
 
-## Sending failable requests
-
-### When your Parcel is the source of truth
-
-* 📐 Feature in design phase
-
-### When you're using a higher state management system
-
-* 📐 Feature in design phase
-
-<Divider />
-
-## Sending partial requests
-
-* 📐 Feature in design phase
-
-<Divider />
-
-## Caching unsaved changes
-
-* 📐 Feature in design phase
-
-<Divider />
-
-## Retaining Parcel keys
-
-* 📐 Feature in design phase
+<SubmitButtonOnChange />
+<Code language="jsx">{SubmitButtonOnChangeSource}</Code>

--- a/packages/dataparcels-docs/src/pages/data-synchronisation.mdx
+++ b/packages/dataparcels-docs/src/pages/data-synchronisation.mdx
@@ -5,6 +5,9 @@ import SubmitButtonOnChange from 'examples/SubmitButtonOnChange';
 import SubmitButtonOnChangeSource from 'examples/SubmitButtonOnChangeSource.txt';
 import SubmitButtonOnChangeClear from 'examples/SubmitButtonOnChangeClear';
 import SubmitButtonOnChangeClearSource from 'examples/SubmitButtonOnChangeClearSource.txt';
+import SubmitButtonOnChangeLoad from 'examples/SubmitButtonOnChangeLoad';
+import SubmitButtonOnChangeLoadSource from 'examples/SubmitButtonOnChangeLoadSource.txt';
+import SubmitButtonOnChangeReduxSource from 'examples/SubmitButtonOnChangeReduxSource.txt';
 
 # Data synchronisation
 
@@ -16,12 +19,34 @@ Data synchronisation encompasses how dataparcels interacts with pieces of data s
 
 The simplest type of data synchronisation is a typical web form that can be submitted. Typical forms are often initially blank, or may occasionally preload some data from a server. Once the form is presented to the user it is the master of its own state. The data flow from this point on is unidirectional e.g. the form sends data to the server, and the server never pushes data back into the form.
 
+This example makes use of the [useParcelForm](/api/useParcelForm) hook. This is the most commonly used hook, and is perfect for building submittable forms.
+
 <SubmitButtonOnChange />
 <Code language="jsx">{SubmitButtonOnChangeSource}</Code>
 
-## Changing or clearing form data after save
+## Clearing a form after submit
 
-You can set the data in the form to something else after it's sent its data by setting `onChangeUseResult` to true. The form's current state will be replaced by whatever returned from `onChange`.
+You can set the data in the form to something else after it's sent its data by setting [onChangeUseResult](/api/useParcelForm#onChangeUseResult) to true. The form's current state will be replaced by whatever returned from `onChange`.
 
 <SubmitButtonOnChangeClear />
 <Code language="jsx">{SubmitButtonOnChangeClearSource}</Code>
+
+## Receiving data from the server after saving
+
+Sometimes the data you're editing in a form corresponds to data in a database somewhere. When this is the case, it's important that the data in your form is an accurate representation of the data in the database whenever possible. Updating the state of your form after saving is a good way to ensure that the state held in your form is refreshed from the server periodically.
+
+Both these examples show forms that make fake requests to a fake server. The fake server will remove any uppercase letters when it saves, and update the `timeUpdated` field. Try typing some uppercase letters into the form, and watch as the data is synchronised with the server's data after the save completes.
+
+### Updating form data via props
+
+If you're using something like [Redux](https://redux.js.org/), you'll likely be receiving your data via props. That data from Redux should already update as a result of save operations. Use the [updateValue](/api/useParcelForm#updateValue) parameter on useParcelForm to allow the form hook to update based on changes to your source data. Also make sure that the function that does the saving returns a promise, so useParcelForm can know if the request succeeded or not.
+
+<SubmitButtonOnChangeLoad />
+<Code language="jsx">{SubmitButtonOnChangeReduxSource}</Code>
+
+### Updating form data via a promise
+
+You may not have centralised state management like Redux in your app. In this case you can get useParcelForm to update based off the return value of the promise returned by the save function. To use this approach, set the [onChangeUseResult](/api/useParcelForm#onChangeUseResult) parameter to true.
+
+<SubmitButtonOnChangeLoad />
+<Code language="jsx">{SubmitButtonOnChangeLoadSource}</Code>

--- a/packages/dataparcels-docs/src/pages/data-synchronisation.mdx
+++ b/packages/dataparcels-docs/src/pages/data-synchronisation.mdx
@@ -3,6 +3,8 @@ import {Code} from 'dcme-style';
 import {Divider} from 'dcme-style';
 import SubmitButtonOnChange from 'examples/SubmitButtonOnChange';
 import SubmitButtonOnChangeSource from 'examples/SubmitButtonOnChangeSource.txt';
+import SubmitButtonOnChangeClear from 'examples/SubmitButtonOnChangeClear';
+import SubmitButtonOnChangeClearSource from 'examples/SubmitButtonOnChangeClearSource.txt';
 
 # Data synchronisation
 
@@ -16,3 +18,10 @@ The simplest type of data synchronisation is a typical web form that can be subm
 
 <SubmitButtonOnChange />
 <Code language="jsx">{SubmitButtonOnChangeSource}</Code>
+
+## Changing or clearing form data after save
+
+You can set the data in the form to something else after it's sent its data by setting `onChangeUseResult` to true. The form's current state will be replaced by whatever returned from `onChange`.
+
+<SubmitButtonOnChangeClear />
+<Code language="jsx">{SubmitButtonOnChangeClearSource}</Code>

--- a/packages/dataparcels-docs/src/pages/index.mdx
+++ b/packages/dataparcels-docs/src/pages/index.mdx
@@ -52,6 +52,8 @@ Data synchronisation encompasses how dataparcels interacts with pieces of data s
 
 **This part of the library is being developed and will be complete soon.**
 
+- <Link to="/data-synchronisation#Saving-data-from-a-form">Saving data from a form</Link>
+
 <Divider />
 
 ## Development

--- a/packages/dataparcels-docs/src/pages/index.mdx
+++ b/packages/dataparcels-docs/src/pages/index.mdx
@@ -53,6 +53,8 @@ Data synchronisation encompasses how dataparcels interacts with pieces of data s
 **This part of the library is being developed and will be complete soon.**
 
 - <Link to="/data-synchronisation#Saving-data-from-a-form">Saving data from a form</Link>
+- <Link to="/data-synchronisation#Clearing-a-form-after-submit">Clearing a form after submit</Link>
+- <Link to="/data-synchronisation#Receiving-data-from-the-server-after-saving">Receiving data from the server after saving</Link>
 
 <Divider />
 

--- a/packages/dataparcels-docs/yalc.lock
+++ b/packages/dataparcels-docs/yalc.lock
@@ -2,7 +2,7 @@
   "version": "v1",
   "packages": {
     "react-dataparcels": {
-      "signature": "6276d6e86d5d8cb9a3ba4bedff42f124",
+      "signature": "98ed7650cc2dadb701231ea440861232",
       "file": true,
       "replaced": "^0.19.0"
     },

--- a/packages/dataparcels-docs/yalc.lock
+++ b/packages/dataparcels-docs/yalc.lock
@@ -2,7 +2,7 @@
   "version": "v1",
   "packages": {
     "react-dataparcels": {
-      "signature": "103cbd44779df7076a729204f0b15b88",
+      "signature": "6276d6e86d5d8cb9a3ba4bedff42f124",
       "file": true,
       "replaced": "^0.19.0"
     },

--- a/packages/dataparcels-docs/yalc.lock
+++ b/packages/dataparcels-docs/yalc.lock
@@ -2,7 +2,7 @@
   "version": "v1",
   "packages": {
     "react-dataparcels": {
-      "signature": "bf3cf47614ad794dc36c0c80634205f1",
+      "signature": "103cbd44779df7076a729204f0b15b88",
       "file": true,
       "replaced": "^0.19.0"
     },

--- a/packages/dataparcels-docs/yarn.lock
+++ b/packages/dataparcels-docs/yarn.lock
@@ -3597,10 +3597,10 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
-dataparcels@^0.21.0-alpha.0:
-  version "0.21.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/dataparcels/-/dataparcels-0.21.0-alpha.0.tgz#14c5e0e74eb20834c8e7957fd6484575ba18c38d"
-  integrity sha512-eP4/qMP/2b1T1Rw0jWJwq8I0rDJkidhKP+f66rYMNoYA+W4YP+tooYfPDozAnivP8HMKtpyCY1ael50LPidLpQ==
+dataparcels@^0.21.0:
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/dataparcels/-/dataparcels-0.21.0.tgz#c0c27a8a7f4850e1c792301eda7c4c4b505a442e"
+  integrity sha512-yLeQxOX8RzbCMfN4fDO4m++nr0mj/2cwXcERMoZYK+Yi/bsXHXGgxEmvfCxZMMrfZsFf3dBfXKGYPL/u6ZiYqw==
   dependencies:
     "@babel/runtime" "^7.1.5"
     unmutable "^0.41.1"
@@ -9688,16 +9688,16 @@ react-cool-storage@^0.1.1:
     unmutable "^0.39.0"
 
 "react-dataparcels-drag@file:.yalc/react-dataparcels-drag":
-  version "0.21.0-alpha.0-ed702c0f"
+  version "0.21.0-fc7aaf63"
   dependencies:
     "@babel/runtime" "^7.1.5"
     react-sortable-hoc "1.4.0"
 
 "react-dataparcels@file:.yalc/react-dataparcels":
-  version "0.21.0-alpha.0-9200b2ef"
+  version "0.21.0-f46cdd75"
   dependencies:
     "@babel/runtime" "^7.1.5"
-    dataparcels "^0.21.0-alpha.0"
+    dataparcels "^0.21.0"
     unmutable "^0.41.1"
     use-debounce "^1.1.3"
 

--- a/packages/dataparcels/.size-limit
+++ b/packages/dataparcels/.size-limit
@@ -12,7 +12,7 @@
         path: "CancelActionMarker.js"
     },
     {
-        limit: "8 KB",
+        limit: "9 KB",
         path: "ChangeRequest.js"
     },
     {

--- a/packages/dataparcels/src/change/ChangeRequest.js
+++ b/packages/dataparcels/src/change/ChangeRequest.js
@@ -25,6 +25,7 @@ export default class ChangeRequest {
     _nextData: ?ParcelData;
     _originId: ?string = null;
     _originPath: ?string[] = null;
+    _revertCallback: ?Function;
 
     constructor(action: Action|Action[] = []) {
         this._actions = this._actions.concat(action);
@@ -38,6 +39,7 @@ export default class ChangeRequest {
             nextData: this._nextData,
             originId: this._originId,
             originPath: this._originPath,
+            revertCallback: this._revertCallback,
             ...changeRequestData
         };
 
@@ -47,6 +49,7 @@ export default class ChangeRequest {
         changeRequest._nextData = changeRequestData.nextData;
         changeRequest._originId = changeRequestData.originId;
         changeRequest._originPath = changeRequestData.originPath;
+        changeRequest._revertCallback = changeRequestData.revertCallback;
         return changeRequest;
     };
 
@@ -56,6 +59,10 @@ export default class ChangeRequest {
             nextData: undefined,
             prevData: undefined
         });
+    };
+
+    _revert = () => {
+        this._revertCallback && this._revertCallback(this);
     };
 
     // $FlowFixMe - this doesn't have side effects

--- a/packages/dataparcels/src/change/__test__/ChangeRequest-test.js
+++ b/packages/dataparcels/src/change/__test__/ChangeRequest-test.js
@@ -392,3 +392,16 @@ test('ChangeRequest should throw errors when attempted to set getters', () => {
         changeRequest.originPath = 123;
     }).toThrow(readOnly);
 });
+
+test('ChangeRequest _revert() should call _revertCallback and pass self', () => {
+
+    let changeRequest = new ChangeRequest();
+    expect(() => changeRequest._revert()).not.toThrow();
+
+    let callback = jest.fn();
+    changeRequest._revertCallback = callback;
+    changeRequest._revert();
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback.mock.calls[0][0]).toBe(changeRequest);
+});

--- a/packages/dataparcels/src/errors/Errors.js
+++ b/packages/dataparcels/src/errors/Errors.js
@@ -5,3 +5,4 @@ export const ReducerInvalidActionError = (actionType: string) => new Error(`"${a
 export const ReducerInvalidStepError = (stepType: string) => new Error(`"${stepType}" is not a valid action step type`);
 export const ChangeRequestNoPrevDataError = () =>  new Error(`ChangeRequest data cannot be accessed before setting changeRequest.prevData`);
 export const ShapeUpdaterNonShapeChildError = () =>  new Error(`Every child value on a collection returned from a shape updater must be a ParcelShape`);
+export const ChangeAndReturnNotCalledError = () =>  new Error(`_changeAndReturn unchanged`);

--- a/packages/dataparcels/src/parcel/Parcel.js
+++ b/packages/dataparcels/src/parcel/Parcel.js
@@ -187,23 +187,23 @@ export default class Parcel {
         }
     };
 
-    _changeAndReturn = (changeCatcher: (parcel: Parcel) => void): Parcel => {
-        let changedParcel = this;
-        let {_onHandleChange} = this;
+    _changeAndReturn = (changeCatcher: (parcel: Parcel) => void): ?[Parcel, ChangeRequest] => {
+        let result;
+        let {_onHandleChange, _lastOriginId} = this;
 
         // swap out the parcels real _onHandleChange with a spy
-        this._onHandleChange = (parcel) => {
-            changedParcel = parcel;
-            changedParcel._onHandleChange = _onHandleChange;
+        this._onHandleChange = (parcel, changeRequest) => {
+            // _changeAndReturn should not alter _lastOriginId
+            // as it's never triggered by a user action
+            // so revert to the current parcel's _lastOriginId
+            parcel._onHandleChange = _onHandleChange;
+            parcel._lastOriginId = _lastOriginId;
+            result = [parcel, changeRequest];
         };
 
         changeCatcher(this);
         this._onHandleChange = _onHandleChange;
-        // _changeAndReturn should not alter _lastOriginId
-        // as it's never triggered by a user action
-        // so revert to the current parcel's _lastOriginId
-        changedParcel._lastOriginId = this._lastOriginId;
-        return changedParcel;
+        return result;
     };
 
     _boundarySplit = ({handleChange}: *): Parcel => {

--- a/packages/dataparcels/src/parcel/Parcel.js
+++ b/packages/dataparcels/src/parcel/Parcel.js
@@ -17,6 +17,7 @@ import type {ParentType} from '../types/Types';
 
 import Types from '../types/Types';
 import {ReadOnlyError} from '../errors/Errors';
+import {ChangeAndReturnNotCalledError} from '../errors/Errors';
 
 import ParcelGetMethods from './methods/ParcelGetMethods';
 import ParcelChangeMethods from './methods/ParcelChangeMethods';
@@ -187,7 +188,7 @@ export default class Parcel {
         }
     };
 
-    _changeAndReturn = (changeCatcher: (parcel: Parcel) => void): ?[Parcel, ChangeRequest] => {
+    _changeAndReturn = (changeCatcher: (parcel: Parcel) => void): [Parcel, ChangeRequest] => {
         let result;
         let {_onHandleChange, _lastOriginId} = this;
 
@@ -203,6 +204,9 @@ export default class Parcel {
 
         changeCatcher(this);
         this._onHandleChange = _onHandleChange;
+        if(!result) {
+            throw ChangeAndReturnNotCalledError();
+        }
         return result;
     };
 

--- a/packages/dataparcels/src/parcel/__test__/Parcel-test.js
+++ b/packages/dataparcels/src/parcel/__test__/Parcel-test.js
@@ -38,7 +38,7 @@ test('Parcel._changeAndReturn() should call action and return Parcel', () => {
     });
     parcel._lastOriginId = "foo";
 
-    let newParcel = parcel._changeAndReturn((parcel) => {
+    let [newParcel] = parcel._changeAndReturn((parcel) => {
         parcel.get('abc').onChange(789);
     });
 

--- a/packages/dataparcels/src/parcel/__test__/Parcel-test.js
+++ b/packages/dataparcels/src/parcel/__test__/Parcel-test.js
@@ -64,6 +64,20 @@ test('Parcel._changeAndReturn() should call action and return Parcel', () => {
     expect(newParcel._lastOriginId).toBe("foo");
 });
 
+test('Parcel._changeAndReturn() should throw error if no changes are made', () => {
+    let handleChange = jest.fn();
+
+    let parcel = new Parcel({
+        value: {
+            abc: 123,
+            def: 456
+        },
+        handleChange
+    });
+
+    expect(() => parcel._changeAndReturn((parcel) => {})).toThrow("_changeAndReturn unchanged");
+});
+
 test('Parcel types should correctly identify primitive values', () => {
     var data = {
         value: 123

--- a/packages/react-dataparcels-drag/src/__test__/Drag-test.js
+++ b/packages/react-dataparcels-drag/src/__test__/Drag-test.js
@@ -1,6 +1,6 @@
 // // @flow
 import React from 'react';
-import Parcel from 'react-dataparcels';
+import Parcel from 'dataparcels';
 import Drag from '../Drag';
 
 test('Drag must pass props correctly', () => {

--- a/packages/react-dataparcels/.size-limit
+++ b/packages/react-dataparcels/.size-limit
@@ -61,6 +61,10 @@
     },
     {
         limit: "14 KB",
+        path: "useParcelSideEffect.js"
+    },
+    {
+        limit: "14 KB",
         path: "useParcelState.js"
     }
 ]

--- a/packages/react-dataparcels/.size-limit
+++ b/packages/react-dataparcels/.size-limit
@@ -12,7 +12,7 @@
         path: "CancelActionMarker.js"
     },
     {
-        limit: "8 KB",
+        limit: "9 KB",
         path: "ChangeRequest.js"
     },
     {

--- a/packages/react-dataparcels/__test__/Exports-test.js
+++ b/packages/react-dataparcels/__test__/Exports-test.js
@@ -18,6 +18,7 @@ import ParcelBoundaryHoc from '../ParcelBoundaryHoc';
 import ParcelBufferControl from '../ParcelBufferControl';
 import useParcelBuffer from '../useParcelBuffer';
 import useParcelForm from '../useParcelForm';
+import useParcelSideEffect from '../useParcelSideEffect';
 import useParcelState from '../useParcelState';
 
 // internal dataparcels files
@@ -38,6 +39,7 @@ import InternalParcelBoundaryHoc from '../lib/ParcelBoundaryHoc';
 import InternalParcelBufferControl from '../lib/ParcelBufferControl';
 import InternalUseParcelBuffer from '../lib/useParcelBuffer';
 import InternalUseParcelForm from '../lib/useParcelForm';
+import InternalUseParcelSideEffect from '../lib/useParcelSideEffect';
 import InternalUseParcelState from '../lib/useParcelState';
 
 test('index should export Parcel', () => {
@@ -98,6 +100,10 @@ test('/useParcelBuffer should export useParcelBuffer', () => {
 
 test('/useParcelForm should export useParcelForm', () => {
     expect(useParcelForm).toBe(InternalUseParcelForm);
+});
+
+test('/useParcelSideEffect should export useParcelSideEffect', () => {
+    expect(useParcelSideEffect).toBe(InternalUseParcelSideEffect);
 });
 
 test('/useParcelState should export useParcelState', () => {

--- a/packages/react-dataparcels/package.json
+++ b/packages/react-dataparcels/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "@babel/runtime": "^7.1.5",
     "dataparcels": "^0.21.0",
+    "is-promise": "^2.1.0",
     "unmutable": "^0.41.1",
     "use-debounce": "^1.1.3"
   },

--- a/packages/react-dataparcels/package.json
+++ b/packages/react-dataparcels/package.json
@@ -24,6 +24,7 @@
     "shape.js",
     "useParcelBuffer.js",
     "useParcelForm.js",
+    "useParcelSideEffect.js",
     "useParcelState.js",
     "Validation.js"
   ],

--- a/packages/react-dataparcels/package.json
+++ b/packages/react-dataparcels/package.json
@@ -57,12 +57,15 @@
     "babel-preset-blueflag": "^1.0.0",
     "blueflag-test": "^0.22.0",
     "immutable": "^4.0.0-rc.12",
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6",
+    "react": "^16.9.0-alpha",
+    "react-dom": "^16.9.0-alpha",
     "react-hooks-testing-library": "^0.5.0",
     "size-limit": "^0.21.1"
   },
   "peerDependencies": {
     "react": "^16.8.0"
+  },
+  "resolutions": {
+    "**/react-test-renderer": "16.9.0-alpha.0"
   }
 }

--- a/packages/react-dataparcels/src/ParcelBoundaryDeprecated.jsx
+++ b/packages/react-dataparcels/src/ParcelBoundaryDeprecated.jsx
@@ -279,7 +279,7 @@ export default class ParcelBoundary extends React.Component<Props, State> { /* e
             ));
         };
 
-        return parcel
+        let [changedParcel] = parcel
             ._boundarySplit({
                 handleChange
             })
@@ -291,6 +291,8 @@ export default class ParcelBoundary extends React.Component<Props, State> { /* e
                 .pipe(ApplyModifyBeforeUpdate(modifyBeforeUpdate))
                 ._setData(nextData || parcel.data)
             );
+
+        return changedParcel;
     };
 
     render(): Node {

--- a/packages/react-dataparcels/src/ParcelHoc.jsx
+++ b/packages/react-dataparcels/src/ParcelHoc.jsx
@@ -92,10 +92,12 @@ export default (config: ParcelHocConfig): Function => {
         }
 
         static updateParcelValueFromProps(parcel: Parcel, props: Props): Parcel {
-            return parcel._changeAndReturn((parcel: Parcel) => {
+            let [changedParcel] = parcel._changeAndReturn((parcel: Parcel) => {
                 let value: any = valueFromProps(props);
                 return ApplyBeforeChange(modifyBeforeUpdate)(parcel).set(value);
             });
+
+            return changedParcel;
         }
 
         static applyModifyBeforeUpdate(parcel: Parcel): Parcel {

--- a/packages/react-dataparcels/src/__mocks__/useParcelSideEffect.js
+++ b/packages/react-dataparcels/src/__mocks__/useParcelSideEffect.js
@@ -1,0 +1,4 @@
+// @flow
+import Parcel from 'dataparcels';
+
+export default jest.fn(() => [new Parcel()]);

--- a/packages/react-dataparcels/src/__test__/useParcelBuffer-test.js
+++ b/packages/react-dataparcels/src/__test__/useParcelBuffer-test.js
@@ -173,7 +173,7 @@ describe('useParcelBuffer should use buffer by default', () => {
         expect(handleChange.mock.calls[0][0].value).toEqual(["A", "B"]);
     });
 
-    it('should try to submit changes but do nothing if there are no changes', () => {
+    it('should submit empty change request if there are no changes', () => {
 
         let handleChange = jest.fn();
 
@@ -190,7 +190,8 @@ describe('useParcelBuffer should use buffer by default', () => {
             result.current[1].submit();
         });
 
-        expect(handleChange).not.toHaveBeenCalled();
+        expect(handleChange).toHaveBeenCalled();
+        expect(handleChange.mock.calls[0][1].actions.length).toBe(0);
     });
 
     it('should reset changes', () => {

--- a/packages/react-dataparcels/src/__test__/useParcelBufferInternalKeepValue-test.js
+++ b/packages/react-dataparcels/src/__test__/useParcelBufferInternalKeepValue-test.js
@@ -90,7 +90,7 @@ describe('useParcelBufferInternalKeepValue should work', () => {
 
         act(() => {
             // pretend that a another change came from 'def', but this time with a changed value
-            parcel = parcel._changeAndReturn(parcel => parcel.set(124));
+            parcel = parcel._changeAndReturn(parcel => parcel.set(124))[0];
             parcel._lastOriginId = "^.def";
 
             rerender({

--- a/packages/react-dataparcels/src/__test__/useParcelForm-test.js
+++ b/packages/react-dataparcels/src/__test__/useParcelForm-test.js
@@ -4,9 +4,11 @@ import {renderHook} from 'react-hooks-testing-library';
 import useParcelForm from '../useParcelForm';
 import useParcelState from '../useParcelState';
 import useParcelBuffer from '../useParcelBuffer';
+import useParcelSideEffect from '../useParcelSideEffect';
 
 jest.mock('../useParcelState.js');
 jest.mock('../useParcelBuffer.js');
+jest.mock('../useParcelSideEffect.js');
 
 const getLastCall = (obj) => obj.mock.calls[obj.mock.calls.length - 1];
 const getLastResult = (obj) => obj.mock.results[obj.mock.results.length - 1].value;
@@ -34,7 +36,21 @@ describe('useParcelForm should pass config to useParcelState', () => {
         expect(getLastCall(useParcelState)[0].updateValue).toBe(true);
     });
 
-    it('should pass onChange to useParcelState', () => {
+});
+
+
+describe('useParcelForm should pass config to useParcelSideEffect', () => {
+
+    it('should pass result of useParcelState to useParcelSideEffect', () => {
+        renderHook(() => useParcelForm({
+            value: 123
+        }));
+
+        expect(getLastCall(useParcelSideEffect)[0].parcel).toBe(getLastResult(useParcelState)[0]);
+        expect(getLastCall(useParcelSideEffect)[0].onChangeUseResult).toBe(false);
+    });
+
+    it('should pass onChange to useParcelSideEffect', () => {
         let onChange = () => {};
 
         renderHook(() => useParcelForm({
@@ -42,19 +58,29 @@ describe('useParcelForm should pass config to useParcelState', () => {
             onChange
         }));
 
-        expect(getLastCall(useParcelState)[0].onChange).toBe(onChange);
+        expect(getLastCall(useParcelSideEffect)[0].onChange).toBe(onChange);
+    });
+
+    it('should pass onChangeUseResult to useParcelSideEffect', () => {
+
+        renderHook(() => useParcelForm({
+            value: 123,
+            onChangeUseResult: true
+        }));
+
+        expect(getLastCall(useParcelSideEffect)[0].onChangeUseResult).toBe(true);
     });
 
 });
 
 describe('useParcelForm should pass config to useParcelBuffer', () => {
 
-    it('should pass result of useParcelState to useParcelBuffer', () => {
+    it('should pass result of useParcelSideEffect to useParcelBuffer', () => {
         renderHook(() => useParcelForm({
             value: 123
         }));
 
-        expect(getLastCall(useParcelBuffer)[0].parcel).toBe(getLastResult(useParcelState)[0]);
+        expect(getLastCall(useParcelBuffer)[0].parcel).toBe(getLastResult(useParcelSideEffect)[0]);
         expect(getLastCall(useParcelBuffer)[0].buffer).toBe(true);
         expect(getLastCall(useParcelBuffer)[0].debounce).toBe(0);
     });

--- a/packages/react-dataparcels/src/__test__/useParcelFormRevert-test.js
+++ b/packages/react-dataparcels/src/__test__/useParcelFormRevert-test.js
@@ -1,0 +1,88 @@
+// @flow
+import {act} from 'react-hooks-testing-library';
+import {renderHook} from 'react-hooks-testing-library';
+import useParcelForm from '../useParcelForm';
+
+
+describe('useParcelForm should revert change request', () => {
+
+    it('should put changes back into buffer from rejected onChange', async () => {
+        let rejectMyPromise;
+        let promise = new Promise((resolve, reject) => {
+            rejectMyPromise = () => {
+                reject();
+                return promise.catch(() => {});
+            };
+        });
+
+        let {result} = renderHook(() => useParcelForm({
+            value: [],
+            onChange: () => promise
+        }));
+
+        act(() => {
+            result.current[0].push(123);
+        });
+
+        expect(result.current[1].actions.length).toBe(1);
+        let firstAction = result.current[1].actions[0];
+
+        act(() => {
+            result.current[1].submit();
+        });
+
+        expect(result.current[1].actions.length).toBe(0);
+
+        await act(async () => {
+            await rejectMyPromise();
+        });
+
+        expect(result.current[0].value).toEqual([123]);
+        expect(result.current[1].actions.length).toBe(1);
+        expect(result.current[1].actions[0]).toBe(firstAction);
+    });
+
+    it('should put changes back into buffer from rejected onChange, onto new changes', async () => {
+        let rejectMyPromise;
+        let promise = new Promise((resolve, reject) => {
+            rejectMyPromise = () => {
+                reject();
+                return promise.catch(() => {});
+            };
+        });
+
+        let {result} = renderHook(() => useParcelForm({
+            value: [],
+            onChange: () => promise
+        }));
+
+        act(() => {
+            result.current[0].push(123);
+        });
+
+        expect(result.current[1].actions.length).toBe(1);
+        let firstAction = result.current[1].actions[0];
+
+        act(() => {
+            result.current[1].submit();
+        });
+
+        expect(result.current[1].actions.length).toBe(0);
+
+        act(() => {
+            result.current[0].push(456);
+        });
+
+        expect(result.current[1].actions.length).toBe(1);
+        let secondAction = result.current[1].actions[0];
+
+        await act(async () => {
+            await rejectMyPromise();
+        });
+
+        expect(result.current[0].value).toEqual([123,456]);
+        expect(result.current[1].actions.length).toBe(2);
+        expect(result.current[1].actions[0]).toBe(firstAction);
+        expect(result.current[1].actions[1]).toBe(secondAction);
+    });
+});

--- a/packages/react-dataparcels/src/__test__/useParcelSideEffect-test.js
+++ b/packages/react-dataparcels/src/__test__/useParcelSideEffect-test.js
@@ -6,6 +6,8 @@ import Parcel from 'dataparcels';
 
 const renderHookWithProps = (initialProps, callback) => renderHook(callback, {initialProps});
 
+const onChangePromise = (onChange, index = 0) => onChange.mock.results[index].value.catch(() => {});
+
 describe('useParcelSideEffect should use config.parcel', () => {
 
     it('should pass through a parcels data', () => {
@@ -84,6 +86,232 @@ describe('useParcelSideEffect should use config.parcel', () => {
         });
 
         expect(result.current[0].value).toEqual(456);
+    });
+
+});
+
+describe('useParcelSideEffect should use config.onChange', () => {
+
+    it('should call onChange with value and change request if provided', () => {
+        let handleChange = jest.fn();
+        let onChange = jest.fn();
+
+        let parcel = new Parcel({
+            value: 123,
+            handleChange
+        });
+
+        let {result} = renderHook(() => useParcelSideEffect({
+            parcel,
+            onChange
+        }));
+
+        act(() => {
+            result.current[0].set(456);
+        });
+
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(onChange.mock.calls[0][0].value).toBe(456);
+        expect(onChange.mock.calls[0][1].prevData.value).toBe(123);
+        expect(handleChange.mock.calls[0][0].value).toBe(456);
+    });
+
+    it('should call onChange with result if onChangeUseResult = true', () => {
+        let handleChange = jest.fn();
+        let onChange = jest.fn(() => 333);
+
+        let parcel = new Parcel({
+            value: [123],
+            handleChange
+        });
+
+        let {result} = renderHook(() => useParcelSideEffect({
+            parcel,
+            onChange,
+            onChangeUseResult: true
+        }));
+
+        act(() => {
+            result.current[0].get(0).set(456);
+        });
+
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(onChange.mock.calls[0][0].value).toEqual([456]);
+        expect(onChange.mock.calls[0][1].prevData.value).toEqual([123]);
+        expect(handleChange.mock.calls[0][0].value).toEqual(333);
+        expect(handleChange.mock.calls[0][1].originId).toBe(onChange.mock.calls[0][1].originId);
+    });
+
+});
+
+
+describe('useParcelSideEffect should use config.onChange with promises', () => {
+
+    it('should call onChange with promise that resolves', async () => {
+        let handleChange = jest.fn();
+        let onChange = jest.fn(() => Promise.resolve(333));
+
+        let parcel = new Parcel({
+            value: 123,
+            handleChange
+        });
+
+        let {result} = renderHook(() => useParcelSideEffect({
+            parcel,
+            onChange
+        }));
+
+        act(() => {
+            result.current[0].set(456);
+        });
+
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(onChange.mock.calls[0][0].value).toBe(456);
+        expect(onChange.mock.calls[0][1].prevData.value).toBe(123);
+        expect(handleChange).toHaveBeenCalledTimes(0);
+
+        await onChangePromise(onChange);
+
+        expect(handleChange).toHaveBeenCalledTimes(1);
+        expect(handleChange.mock.calls[0][0].value).toBe(456);
+    });
+
+    it('should not call onChange with promise that rejects', async () => {
+        let handleChange = jest.fn();
+        let onChange = jest.fn(() => Promise.reject('error'));
+
+        let parcel = new Parcel({
+            value: 123,
+            handleChange
+        });
+
+        let {result} = renderHook(() => useParcelSideEffect({
+            parcel,
+            onChange
+        }));
+
+        act(() => {
+            result.current[0].set(456);
+        });
+
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(onChange.mock.calls[0][0].value).toBe(456);
+        expect(onChange.mock.calls[0][1].prevData.value).toBe(123);
+
+        expect(handleChange).toHaveBeenCalledTimes(0);
+
+        await onChangePromise(onChange);
+
+        expect(handleChange).toHaveBeenCalledTimes(0);
+        // test for revert...
+    });
+
+    it('should call onChange with promise that resolves with result if onChangeUseResult = true', async () => {
+        let handleChange = jest.fn();
+        let onChange = jest.fn(() => Promise.resolve(333));
+
+        let parcel = new Parcel({
+            value: 123,
+            handleChange
+        });
+
+        let {result} = renderHook(() => useParcelSideEffect({
+            parcel,
+            onChange,
+            onChangeUseResult: true
+        }));
+
+        act(() => {
+            result.current[0].set(456);
+        });
+
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(onChange.mock.calls[0][0].value).toBe(456);
+        expect(onChange.mock.calls[0][1].prevData.value).toBe(123);
+        expect(handleChange).toHaveBeenCalledTimes(0);
+
+        await onChangePromise(onChange);
+
+        expect(handleChange).toHaveBeenCalledTimes(1);
+        expect(handleChange.mock.calls[0][0].value).toBe(333);
+    });
+
+    it('should merge subsequent onChange if promise resolves twice', async () => {
+        let handleChange = jest.fn();
+        let onChange = jest.fn();
+        onChange
+            .mockReturnValueOnce(Promise.resolve())
+            .mockReturnValueOnce(Promise.resolve());
+
+        let parcel = new Parcel({
+            value: [],
+            handleChange
+        });
+
+        let {result} = renderHook(() => useParcelSideEffect({
+            parcel,
+            onChange
+        }));
+
+        act(() => {
+            result.current[0].push(123);
+            result.current[0].push(456);
+        });
+
+        // only process one change at a time...
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(onChange.mock.calls[0][0].value).toEqual([123]);
+        expect(onChange.mock.calls[0][1].prevData.value).toEqual([]);
+
+        // wait until the first promise is complete before firing off anything
+        expect(handleChange).toHaveBeenCalledTimes(0);
+
+        await onChangePromise(onChange);
+
+        expect(onChange).toHaveBeenCalledTimes(2);
+        expect(onChange.mock.calls[1][0].value).toEqual([123, 456]);
+        expect(onChange.mock.calls[1][1].prevData.value).toEqual([]);
+        expect(handleChange).toHaveBeenCalledTimes(1);
+        expect(handleChange.mock.calls[0][0].value).toEqual([123, 456]);
+    });
+
+    it('should merge subsequent onChange if promise rejects and then resolves', async () => {
+        let handleChange = jest.fn();
+        let onChange = jest.fn();
+        onChange
+            .mockReturnValueOnce(Promise.reject())
+            .mockReturnValueOnce(Promise.resolve());
+
+        let parcel = new Parcel({
+            value: [],
+            handleChange
+        });
+
+        let {result} = renderHook(() => useParcelSideEffect({
+            parcel,
+            onChange
+        }));
+
+        act(() => {
+            result.current[0].push(123);
+            result.current[0].push(456);
+        });
+
+        // only process one change at a time...
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(onChange.mock.calls[0][0].value).toEqual([123]);
+        expect(onChange.mock.calls[0][1].prevData.value).toEqual([]);
+
+        // wait until the first promise is complete before firing off anything
+        expect(handleChange).toHaveBeenCalledTimes(0);
+
+        await onChangePromise(onChange);
+
+        expect(onChange).toHaveBeenCalledTimes(2);
+        expect(onChange.mock.calls[1][0].value).toEqual([123, 456]);
+        expect(onChange.mock.calls[1][1].prevData.value).toEqual([]);
+        expect(handleChange).toHaveBeenCalledTimes(1);
+        expect(handleChange.mock.calls[0][0].value).toEqual([123, 456]);
     });
 
 });

--- a/packages/react-dataparcels/src/__test__/useParcelSideEffect-test.js
+++ b/packages/react-dataparcels/src/__test__/useParcelSideEffect-test.js
@@ -2,6 +2,7 @@
 import {act} from 'react-hooks-testing-library';
 import {renderHook} from 'react-hooks-testing-library';
 import useParcelSideEffect from '../useParcelSideEffect';
+import useParcelBuffer from '../useParcelBuffer';
 import Parcel from 'dataparcels';
 
 const renderHookWithProps = (initialProps, callback) => renderHook(callback, {initialProps});
@@ -313,5 +314,4 @@ describe('useParcelSideEffect should use config.onChange with promises', () => {
         expect(handleChange).toHaveBeenCalledTimes(1);
         expect(handleChange.mock.calls[0][0].value).toEqual([123, 456]);
     });
-
 });

--- a/packages/react-dataparcels/src/__test__/useParcelSideEffect-test.js
+++ b/packages/react-dataparcels/src/__test__/useParcelSideEffect-test.js
@@ -1,0 +1,89 @@
+// @flow
+import {act} from 'react-hooks-testing-library';
+import {renderHook} from 'react-hooks-testing-library';
+import useParcelSideEffect from '../useParcelSideEffect';
+import Parcel from 'dataparcels';
+
+const renderHookWithProps = (initialProps, callback) => renderHook(callback, {initialProps});
+
+describe('useParcelSideEffect should use config.parcel', () => {
+
+    it('should pass through a parcels data', () => {
+        let parcel = new Parcel({
+            value: 123
+        });
+
+        let {result} = renderHook(() => useParcelSideEffect({parcel}));
+
+        expect(result.current[0].data).toEqual({
+            value: 123,
+            child: undefined,
+            key: '^',
+            meta: {}
+        });
+    });
+
+    it('should pass through a parcel on first hook call', () => {
+        let parcel = new Parcel();
+        let hookRenderer = jest.fn(() => useParcelSideEffect({parcel}));
+
+        renderHook(hookRenderer);
+        expect(hookRenderer.mock.results[0].value[0] instanceof Parcel).toBe(true);
+    });
+
+    it('should propagate parcel change immediately', () => {
+        let handleChange = jest.fn();
+
+        let parcel = new Parcel({
+            value: 123,
+            handleChange
+        });
+
+        let {result} = renderHook(() => useParcelSideEffect({parcel, buffer: false}));
+
+        act(() => {
+            result.current[0].set(456);
+        });
+
+        expect(handleChange.mock.calls[0][0].value).toBe(456);
+    });
+
+    it('should pass same inner parcel if outer parcel is the same', () => {
+
+        let parcel = new Parcel({
+            value: 123
+        });
+
+        let {result, rerender} = renderHookWithProps({parcel}, ({parcel}) => useParcelSideEffect({parcel}));
+
+        let firstResult = result.current[0];
+
+        act(() => {
+            rerender({
+                parcel
+            });
+        });
+
+        expect(result.current[0]).toBe(firstResult);
+    });
+
+    it('should pass new inner parcel if outer parcel is different', () => {
+
+        let parcel = new Parcel({
+            value: 123
+        });
+
+        let {result, rerender} = renderHookWithProps({parcel}, ({parcel}) => useParcelSideEffect({parcel}));
+
+        act(() => {
+            rerender({
+                parcel: new Parcel({
+                    value: 456
+                })
+            });
+        });
+
+        expect(result.current[0].value).toEqual(456);
+    });
+
+});

--- a/packages/react-dataparcels/src/useParcelBuffer.js
+++ b/packages/react-dataparcels/src/useParcelBuffer.js
@@ -133,11 +133,6 @@ export default (params: Params): Return => {
         const handleChange = (newParcel: Parcel, changeRequest: ChangeRequest) => {
             const {debounce, buffer = true, keepValue} = params;
 
-            // trigger buffer actions if meta says so
-            const {_submit, _reset} = newParcel.meta;
-            _submit && internalBuffer.submit();
-            _reset && internalBuffer.reset();
-
             // remove buffer actions meta from change request
             // and push any remaining change into the buffer
             let actions = changeRequest._actions.filter(removeInternalMeta);
@@ -145,19 +140,24 @@ export default (params: Params): Return => {
                 internalBuffer.push(changeRequest._create({actions}));
             }
 
-            if(!buffer) {
+            if(buffer) {
+                // if buffer is to be used, update inner parcel immediately
+                // and request a debounced submit if debounce is set
+                setInnerParcel(newParcel.pipe(applyModifiers));
+                debounce && debounceRelease();
+
+            } else {
                 // if no buffer, just propagate it immediately
                 internalBuffer.submit();
                 // if keepValue is true, the buffer is in change of its own state
                 // rather than waiting for new props containing the new value
                 keepValue && setInnerParcel(newParcel.pipe(applyModifiers));
-                return;
             }
 
-            // if buffer is to be used, update inner parcel immediately
-            // and request a debounced submit if debounce is set
-            setInnerParcel(newParcel.pipe(applyModifiers));
-            debounce && debounceRelease();
+            // trigger buffer actions if meta says so
+            const {_submit, _reset} = newParcel.meta;
+            _submit && internalBuffer.submit();
+            _reset && internalBuffer.reset();
         };
 
         const newOuterParcel = params.parcel;

--- a/packages/react-dataparcels/src/useParcelBuffer.js
+++ b/packages/react-dataparcels/src/useParcelBuffer.js
@@ -80,9 +80,11 @@ export default (params: Params): Return => {
             child: innerParcel.child
         };
 
-        return parcel._changeAndReturn(
+        let [changedParcel] = parcel._changeAndReturn(
             parcel => parcel._setData(data)
         );
+
+        return changedParcel;
     };
 
     const prepareInnerParcelFromOuter = () => {

--- a/packages/react-dataparcels/src/useParcelBuffer.js
+++ b/packages/react-dataparcels/src/useParcelBuffer.js
@@ -38,8 +38,7 @@ type Return = [Parcel, ParcelBufferControl];
 
 export default (params: Params): Return => {
 
-    const beforeChange = [].concat(params.beforeChange || []);
-    const applyBeforeChange = ApplyBeforeChange(beforeChange);
+    const applyBeforeChange = ApplyBeforeChange(params.beforeChange);
 
     //
     // parcel state and change logic

--- a/packages/react-dataparcels/src/useParcelBuffer.js
+++ b/packages/react-dataparcels/src/useParcelBuffer.js
@@ -105,6 +105,11 @@ export default (params: Params): Return => {
         onReset: () => setOuterParcel(null),
         // ^ resets by recreating innerParcel from outerParcel
         onSubmit: (changeRequest) => {
+
+            changeRequest._revertCallback = (changeRequest: ChangeRequest) => {
+                internalBuffer.unshift(changeRequest);
+            };
+
             params.parcel.dispatch(changeRequest);
         }
         // ^ submits by dispatching the buffered change request

--- a/packages/react-dataparcels/src/useParcelBufferInternalBuffer.js
+++ b/packages/react-dataparcels/src/useParcelBufferInternalBuffer.js
@@ -16,7 +16,8 @@ type Return = {
     bufferState: ?ChangeRequest,
     push: Function,
     reset: Function,
-    submit: Function
+    submit: Function,
+    unshift: Function
 };
 
 export default ({onSubmit, onReset}: Params): Return => {
@@ -57,10 +58,19 @@ export default ({onSubmit, onReset}: Params): Return => {
         }
     };
 
+    const unshift = (changeRequest: ChangeRequest) => {
+        bufferRef.current = bufferRef.current
+            ? changeRequest.merge(bufferRef.current)
+            : changeRequest;
+
+        updateBufferState();
+    };
+
     return {
         bufferState,
         push,
         reset,
-        submit
+        submit,
+        unshift
     };
 };

--- a/packages/react-dataparcels/src/useParcelBufferInternalBuffer.js
+++ b/packages/react-dataparcels/src/useParcelBufferInternalBuffer.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type ChangeRequest from 'dataparcels/ChangeRequest';
+import ChangeRequest from 'dataparcels/ChangeRequest';
 
 // $FlowFixMe - useState is a named export of react
 import {useRef} from 'react';
@@ -52,6 +52,8 @@ export default ({onSubmit, onReset}: Params): Return => {
             onSubmit(changeRequest);
             bufferRef.current = null;
             updateBufferState();
+        } else {
+            onSubmit(new ChangeRequest());
         }
     };
 

--- a/packages/react-dataparcels/src/useParcelForm.js
+++ b/packages/react-dataparcels/src/useParcelForm.js
@@ -8,16 +8,18 @@ import type ChangeRequest from 'dataparcels/ChangeRequest';
 import type {ParcelValueUpdater} from 'dataparcels';
 
 import useParcelState from './useParcelState';
+import useParcelSideEffect from './useParcelSideEffect';
 import useParcelBuffer from './useParcelBuffer';
 import ParcelBufferControl from './ParcelBufferControl';
 
 type Params = {
     value: any,
     updateValue?: boolean,
-    onChange?: (value: any, changeRequest: ChangeRequest) => void,
+    onChange?: (parcel: Parcel, changeRequest: ChangeRequest) => any|Promise<any>,
+    onChangeUseResult?: boolean,
     buffer?: boolean,
     debounce?: number,
-    validation: ParcelValueUpdater|() => ParcelValueUpdater,
+    validation?: ParcelValueUpdater|() => ParcelValueUpdater,
     beforeChange?: ParcelValueUpdater|ParcelValueUpdater[]
 };
 
@@ -29,6 +31,7 @@ export default (params: Params): Return => {
         value,
         updateValue = false,
         onChange,
+        onChangeUseResult = false,
         buffer = true,
         debounce = 0,
         validation,
@@ -47,12 +50,17 @@ export default (params: Params): Return => {
 
     let [outerParcel] = useParcelState({
         value,
-        updateValue,
-        onChange
+        updateValue
+    });
+
+    let [sideEffectParcel] = useParcelSideEffect({
+        parcel: outerParcel,
+        onChange,
+        onChangeUseResult
     });
 
     let [innerParcel, innerParcelControl] = useParcelBuffer({
-        parcel: outerParcel,
+        parcel: sideEffectParcel,
         buffer,
         debounce,
         beforeChange

--- a/packages/react-dataparcels/src/useParcelSideEffect.js
+++ b/packages/react-dataparcels/src/useParcelSideEffect.js
@@ -1,43 +1,136 @@
 // @flow
 
 import type ChangeRequest from 'dataparcels/ChangeRequest';
-import type {ParcelValueUpdater} from 'dataparcels';
 
+// $FlowFixMe - useState is a named export of react
+import {useRef} from 'react';
 // $FlowFixMe - useState is a named export of react
 import {useState} from 'react';
 
+import isPromise from 'is-promise';
 import Parcel from 'dataparcels';
-import ApplyBeforeChange from './util/ApplyBeforeChange';
+
+type QueueItem = [Parcel, ChangeRequest];
+
+const mergeQueue = (parcel: Parcel, queue: QueueItem[]): QueueItem[] => {
+    if(queue.length < 2) {
+        return queue;
+    }
+
+    let mergedChangeRequests = queue
+        .map(([/*parcel*/, changeRequest]) => changeRequest)
+        .reduce((prev, next) => prev.merge(next));
+
+    let mergedQueueItem = parcel._changeAndReturn(
+        newParcel => newParcel.dispatch(mergedChangeRequests)
+    );
+
+    return [mergedQueueItem];
+};
 
 type Params = {
     parcel: Parcel,
     onChange?: (parcel: Parcel, changeRequest: ChangeRequest) => any|Promise<any>,
-    onChangeUseResult?: boolean,
-    beforeChange?: ParcelValueUpdater|ParcelValueUpdater[]
+    onChangeUseResult?: boolean
 };
 
 type Return = [Parcel];
 
 export default (params: Params): Return => {
 
-    const applyBeforeChange = ApplyBeforeChange(params.beforeChange);
+    //
+    // state
+    //
 
     // outerParcel is locked to changes in props
     const [outerParcel, setOuterParcel] = useState(null);
     // innerParcel is a modified parcel derived from outerParcel
     const [innerParcel, setInnerParcel] = useState(null);
 
-    let handleChange = (newParcel: Parcel, changeRequest: ChangeRequest) => {
-        params.parcel.dispatch(changeRequest);
+    //
+    // queue
+    //
+
+    const queueRef = useRef([]);
+    const pendingRef = useRef(false);
+
+    //
+    // queue processing
+    //
+
+    const processChangeDone = (onDispatch: Function) => (result: any) => {
+        pendingRef.current = false;
+        if(queueRef.current.length > 1) {
+            processChange();
+        } else {
+            let [newParcel, changeRequest] = queueRef.current.shift();
+            onDispatch(newParcel, changeRequest, result);
+        }
     };
+
+    const processChangeSuccess = processChangeDone((newParcel: Parcel, changeRequest: ChangeRequest, result: any) => {
+
+        if(params.onChange && params.onChangeUseResult) {
+            let [/*parcel*/, changeRequestWithResult] = newParcel._changeAndReturn(
+                newParcel => newParcel.set(result)
+            );
+            changeRequestWithResult._originId = changeRequest._originId;
+            changeRequestWithResult._originPath = changeRequest._originPath;
+            changeRequest = changeRequestWithResult;
+        }
+
+        params.parcel.dispatch(changeRequest);
+    });
+
+    const processChangeError = processChangeDone(() => {
+        queueRef.current = [];
+        // in future, revert the change request, as this obviously hasn't gone well...
+    });
+
+    const processChange = () => {
+        let {onChange} = params;
+
+        // if no onChange is present, success! skip to the end
+        if(!onChange) {
+            processChangeSuccess();
+            return;
+        }
+
+        // merge remaining changes in the queue together
+        queueRef.current = mergeQueue(params.parcel, queueRef.current);
+        let result = onChange(...queueRef.current[0]);
+
+        // if a promise isn't returned, success! skip to the end
+        if(!isPromise(result)) {
+            processChangeSuccess(result);
+            return;
+        }
+
+        pendingRef.current = true;
+        // $FlowFixMe - flow can't tell that isPromise() guarantees
+        // that this is a promise
+        result.then(processChangeSuccess, processChangeError);
+    };
+
+    //
+    // update inner parcel when outer parcel changes (or is first set)
+    //
 
     let newInnerParcel;
     if(params.parcel !== outerParcel) {
 
-        newInnerParcel = params.parcel
-            ._boundarySplit({handleChange})
-            .pipe(applyBeforeChange);
+        let handleChange = (newParcel: Parcel, changeRequest: ChangeRequest) => {
 
+            // all changes go into the queue
+            queueRef.current.push([newParcel, changeRequest]);
+
+            // if nothing is pending, then call onChange
+            if(!pendingRef.current) {
+                processChange();
+            }
+        };
+
+        newInnerParcel = params.parcel._boundarySplit({handleChange});
         setOuterParcel(params.parcel);
         setInnerParcel(newInnerParcel);
     }

--- a/packages/react-dataparcels/src/useParcelSideEffect.js
+++ b/packages/react-dataparcels/src/useParcelSideEffect.js
@@ -1,0 +1,52 @@
+// @flow
+
+import type ChangeRequest from 'dataparcels/ChangeRequest';
+import type {ParcelValueUpdater} from 'dataparcels';
+
+// $FlowFixMe - useState is a named export of react
+import {useState} from 'react';
+
+import Parcel from 'dataparcels';
+import ApplyBeforeChange from './util/ApplyBeforeChange';
+
+type Params = {
+    parcel: Parcel,
+    onChange?: (parcel: Parcel, changeRequest: ChangeRequest) => any|Promise<any>,
+    onChangeUseResult?: boolean,
+    beforeChange?: ParcelValueUpdater|ParcelValueUpdater[]
+};
+
+type Return = [Parcel];
+
+export default (params: Params): Return => {
+
+    const applyBeforeChange = ApplyBeforeChange(params.beforeChange);
+
+    // outerParcel is locked to changes in props
+    const [outerParcel, setOuterParcel] = useState(null);
+    // innerParcel is a modified parcel derived from outerParcel
+    const [innerParcel, setInnerParcel] = useState(null);
+
+    let handleChange = (newParcel: Parcel, changeRequest: ChangeRequest) => {
+        params.parcel.dispatch(changeRequest);
+    };
+
+    let newInnerParcel;
+    if(params.parcel !== outerParcel) {
+
+        newInnerParcel = params.parcel
+            ._boundarySplit({handleChange})
+            .pipe(applyBeforeChange);
+
+        setOuterParcel(params.parcel);
+        setInnerParcel(newInnerParcel);
+    }
+
+    let returnedParcel: Parcel = innerParcel || newInnerParcel;
+
+    //
+    // return
+    //
+
+    return [returnedParcel];
+};

--- a/packages/react-dataparcels/src/useParcelSideEffect.js
+++ b/packages/react-dataparcels/src/useParcelSideEffect.js
@@ -82,9 +82,9 @@ export default (params: Params): Return => {
         params.parcel.dispatch(changeRequest);
     });
 
-    const processChangeError = processChangeDone(() => {
+    const processChangeError = processChangeDone((newParcel: Parcel, changeRequest: ChangeRequest) => {
+        changeRequest._revert();
         queueRef.current = [];
-        // in future, revert the change request, as this obviously hasn't gone well...
     });
 
     const processChange = () => {

--- a/packages/react-dataparcels/src/useParcelState.js
+++ b/packages/react-dataparcels/src/useParcelState.js
@@ -28,9 +28,7 @@ export default (params: Params): Return => {
     // so that all changes made to the returned parcel
     // go up through all of beforeChange's functions
 
-    let beforeChange = [].concat(params.beforeChange || []);
-
-    const applyBeforeChange = ApplyBeforeChange(beforeChange);
+    const applyBeforeChange = ApplyBeforeChange(params.beforeChange);
 
     //
     // debounce

--- a/packages/react-dataparcels/src/useParcelState.js
+++ b/packages/react-dataparcels/src/useParcelState.js
@@ -42,11 +42,14 @@ export default (params: Params): Return => {
     // so that all changes made to the returned parcel
     // go up through all of beforeChange's functions
 
-    const updateParcelValue = (parcel: Parcel): Parcel => applyBeforeChange(
-        parcel._changeAndReturn(
+    const updateParcelValue = (parcel: Parcel): Parcel => {
+
+        let [changedParcel] = parcel._changeAndReturn(
             parcel => applyBeforeChange(parcel).set(getValue())
-        )
-    );
+        );
+
+        return applyBeforeChange(changedParcel);
+    };
 
     const [parcel, setParcel] = useState(() => updateParcelValue(
         new Parcel({

--- a/packages/react-dataparcels/src/util/ApplyBeforeChange.js
+++ b/packages/react-dataparcels/src/util/ApplyBeforeChange.js
@@ -2,9 +2,11 @@
 import type {ParcelValueUpdater} from 'dataparcels';
 import type Parcel from 'dataparcels';
 
-export default (beforeChange: ParcelValueUpdater[]) => {
-    return (parcel: Parcel): Parcel => beforeChange.reduceRight(
-        (parcel, updater) => parcel.modifyUp(updater),
-        parcel
-    );
+export default (beforeChange: ?ParcelValueUpdater|ParcelValueUpdater[]) => {
+    return (parcel: Parcel): Parcel => []
+        .concat(beforeChange || [])
+        .reduceRight(
+            (parcel, updater) => parcel.modifyUp(updater),
+            parcel
+        );
 };

--- a/packages/react-dataparcels/src/util/pipeWithFakePrevParcel.js
+++ b/packages/react-dataparcels/src/util/pipeWithFakePrevParcel.js
@@ -6,7 +6,7 @@ import Parcel from 'dataparcels';
 import dangerouslyUpdateParcelData from 'dataparcels/dangerouslyUpdateParcelData';
 
 export default (prevParcel: ?Parcel, ...pipe: ParcelUpdater[]) => (parcel: Parcel): Parcel => {
-    return parcel._changeAndReturn((parcel) => {
+    let [changedParcel] = parcel._changeAndReturn((parcel) => {
 
         let setPrevParcel;
         if(prevParcel) {
@@ -19,4 +19,6 @@ export default (prevParcel: ?Parcel, ...pipe: ParcelUpdater[]) => (parcel: Parce
             .pipe(...pipe)
             ._setData(parcel.data);
     });
+
+    return changedParcel;
 };

--- a/packages/react-dataparcels/useParcelSideEffect.js
+++ b/packages/react-dataparcels/useParcelSideEffect.js
@@ -1,0 +1,2 @@
+/* eslint-disable */
+module.exports = require('./lib/useParcelSideEffect.js');

--- a/packages/react-dataparcels/yarn.lock
+++ b/packages/react-dataparcels/yarn.lock
@@ -2416,14 +2416,6 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
-dataparcels@^0.21.0:
-  version "0.21.0"
-  resolved "https://registry.yarnpkg.com/dataparcels/-/dataparcels-0.21.0.tgz#c0c27a8a7f4850e1c792301eda7c4c4b505a442e"
-  integrity sha512-yLeQxOX8RzbCMfN4fDO4m++nr0mj/2cwXcERMoZYK+Yi/bsXHXGgxEmvfCxZMMrfZsFf3dBfXKGYPL/u6ZiYqw==
-  dependencies:
-    "@babel/runtime" "^7.1.5"
-    unmutable "^0.41.1"
-
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"

--- a/packages/react-dataparcels/yarn.lock
+++ b/packages/react-dataparcels/yarn.lock
@@ -2416,6 +2416,14 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
+dataparcels@^0.21.0:
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/dataparcels/-/dataparcels-0.21.0.tgz#c0c27a8a7f4850e1c792301eda7c4c4b505a442e"
+  integrity sha512-yLeQxOX8RzbCMfN4fDO4m++nr0mj/2cwXcERMoZYK+Yi/bsXHXGgxEmvfCxZMMrfZsFf3dBfXKGYPL/u6ZiYqw==
+  dependencies:
+    "@babel/runtime" "^7.1.5"
+    unmutable "^0.41.1"
+
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
@@ -4204,6 +4212,7 @@ is-primitive@^2.0.0:
 is-promise@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
+  integrity sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=
 
 is-regex@^1.0.4:
   version "1.0.4"

--- a/packages/react-dataparcels/yarn.lock
+++ b/packages/react-dataparcels/yarn.lock
@@ -2416,6 +2416,14 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
+dataparcels@^0.21.0:
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/dataparcels/-/dataparcels-0.21.0.tgz#c0c27a8a7f4850e1c792301eda7c4c4b505a442e"
+  integrity sha512-yLeQxOX8RzbCMfN4fDO4m++nr0mj/2cwXcERMoZYK+Yi/bsXHXGgxEmvfCxZMMrfZsFf3dBfXKGYPL/u6ZiYqw==
+  dependencies:
+    "@babel/runtime" "^7.1.5"
+    unmutable "^0.41.1"
+
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
@@ -6481,14 +6489,15 @@ react-dom@15.5.4:
     object-assign "^4.1.0"
     prop-types "~15.5.7"
 
-react-dom@^16.8.6:
-  version "16.8.6"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
+react-dom@^16.9.0-alpha:
+  version "16.9.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.9.0-alpha.0.tgz#9dfaec18ac1a500fa72cab7b70f2ae29d0cd7716"
+  integrity sha512-BQ5gN42yIPuTnBvE6K9vSjNfDRpSNcYCs2sUx9XR5VaWKwlHTt3G6qIWK6zdXy8TYKb1+IxpsAI0RtbRdXQZ2A==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.13.6"
+    scheduler "^0.14.0-alpha.0"
 
 react-hooks-testing-library@^0.5.0:
   version "0.5.0"
@@ -6500,14 +6509,20 @@ react-is@^16.8.1, react-is@^16.8.6:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
 
-react-test-renderer@^16.0.0-0:
-  version "16.8.6"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.8.6.tgz#188d8029b8c39c786f998aa3efd3ffe7642d5ba1"
+react-is@^16.9.0-alpha.0:
+  version "16.9.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0-alpha.0.tgz#af943642da49460f9fe98630182b0a62db3e9e6a"
+  integrity sha512-psl0ePLTFliYfwcbwvimLgTNN156ZdeWB4zvP7dV/6lTAqWMHFfidg/mSZ2fFgE1LMNN8ZJOLl2DfZ8yg+3ETA==
+
+react-test-renderer@16.9.0-alpha.0, react-test-renderer@^16.0.0-0:
+  version "16.9.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.9.0-alpha.0.tgz#60f584601dc73543dadbe3bca815e1acc8adcaba"
+  integrity sha512-eDl0oVFo6PGY1wpYFs0ezBpZhOgVce5TSta9UPLanshTi4z8NhlM6IgO8KBdioQ5H5/pmyGxOVtpUxJOt19NAQ==
   dependencies:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    react-is "^16.8.6"
-    scheduler "^0.13.6"
+    react-is "^16.9.0-alpha.0"
+    scheduler "^0.14.0-alpha.0"
 
 react@15.5.4:
   version "15.5.4"
@@ -6518,14 +6533,15 @@ react@15.5.4:
     object-assign "^4.1.0"
     prop-types "^15.5.7"
 
-react@^16.8.6:
-  version "16.8.6"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"
+react@^16.9.0-alpha:
+  version "16.9.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.9.0-alpha.0.tgz#e350f3d8af36e3251079cbc90d304620e2f78ccb"
+  integrity sha512-y4bu7rJvtnPPsIwOj7sp5Y2SqlOb0jFupfkdjWxxn8ZeqzUARgpR9wJBUVwW1/QosVdOblmApjo/j6iiAXnebA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.13.6"
+    scheduler "^0.14.0-alpha.0"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -6929,9 +6945,10 @@ sax@~0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/sax/-/sax-0.6.1.tgz#563b19c7c1de892e09bfc4f2fc30e3c27f0952b9"
 
-scheduler@^0.13.6:
-  version "0.13.6"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
+scheduler@^0.14.0-alpha.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.14.0.tgz#b392c23c9c14bfa2933d4740ad5603cc0d59ea5b"
+  integrity sha512-9CgbS06Kki2f4R9FjLSITjZo5BZxPsryiRNyL3LpvrM9WxcVmhlqAOc9E+KQbeI2nqej4JIIbOsfdL51cNb4Iw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
Addresses #181

## react-dataparcels
- **BREAKING CHANGE** `useParcelBuffer` now submits when buffer is empty
  - before, calling submit on an empty buffer did nothing, but this makes it very difficult to resubmit, and considering how easy it is to cancel a change based on whats in it (i.e. `changeRequest.hasValueChanged()`) then changing this behaviour makes it easier to use in general
- Add ability for `useParcelForm()` `onChange` to return promise, and changes are halted until resolve
  - subsequent submits are queued behind pending `onChange`
  - rejected `onChange`s are retried if other changes are submitted before all `onChange`s complete
  - if final `onChange` rejects, the ChangeRequest is pushed back down into the parcel buffer so  editing can continue seamlessly
  - added an internal `useParcelSideEffect()` hook to do all the above
- Add `useParcelForm()` `onChangeUseResult` option, so that the result of `onChange` can set the value in `useParcelForm()` state
