### PR TITLE
Feature/on submit

### DIFF
--- a/packages/dataparcels-docs/src/content/API.js
+++ b/packages/dataparcels-docs/src/content/API.js
@@ -43,6 +43,14 @@ export default () => <Box>
         image={IconParcelBoundary}
     />
     <Item
+        name="useParcelForm"
+        description={<Box>
+            <Text element="p" modifier="marginMilli">useParcelForm is a React hook.</Text>
+            <Text element="p">Its job is to make submittable forms easy to build. It provides a parcel stored in state and a buffer to store unsaved changes, and also handles how the parcel responds to changes in React props.</Text>
+        </Box>}
+        image={IconParcelHoc}
+    />
+    <Item
         name="useParcelState"
         description={<Box>
             <Text element="p" modifier="marginMilli">useParcelState is a React hook.</Text>
@@ -50,26 +58,11 @@ export default () => <Box>
         </Box>}
         image={IconParcelHoc}
     />
-    <Item
-        name="useParcelForm"
-        description={<Box>
-            <Text element="p" modifier="marginMilli">useParcelForm is a React hook.</Text>
-            <Text element="p">Its job is to make submittable forms easy to build, by combining useParcelState and useParcelBuffer together.</Text>
-        </Box>}
-        image={IconParcelBoundaryHoc}
-    />
-    <Item
-        name="useParcelBuffer"
-        description={<Box>
-            <Text element="p" modifier="marginMilli">useParcelBuffer is a React hook.</Text>
-            <Text element="p">Its job is to control the flow of parcel changes by providing a buffer.</Text>
-        </Box>}
-        image={IconParcelBoundaryHoc}
-    />
     <Text element="h3" modifier="marginKilo sizeKilo">See also</Text>
     <BulletList>
         <BulletListItem><Link className="Link" to="/api/ParcelDrag">ParcelDrag</Link></BulletListItem>
         <BulletListItem><Link className="Link" to="/api/validation">validation</Link></BulletListItem>
+        <BulletListItem><Link className="Link" to="/api/useParcelBuffer">useParcelBuffer</Link></BulletListItem>
         <BulletListItem><Link className="Link" to="/api/ChangeRequest">ChangeRequest</Link></BulletListItem>
         <BulletListItem><Link className="Link" to="/api/CancelActionMarker">CancelActionMarker</Link></BulletListItem>
         <BulletListItem><Link className="Link" to="/api/ParcelShape">ParcelShape</Link></BulletListItem>

--- a/packages/dataparcels-docs/src/examples/SubmitButtonOnChange.jsx
+++ b/packages/dataparcels-docs/src/examples/SubmitButtonOnChange.jsx
@@ -25,7 +25,7 @@ export default function SignUpForm(props) {
 
     let [personParcel, personParcelControl] = useParcelForm({
         value: initialValue,
-        onChange: (parcel) => saveMyData(parcel.value)
+        onSubmit: (parcel) => saveMyData(parcel.value)
         // ^ returns a promise
     });
 
@@ -43,8 +43,8 @@ export default function SignUpForm(props) {
 
         <button onClick={() => personParcelControl.submit()}>Submit</button>
 
-        <p>Request state: <strong>{personParcelControl.onChangeStatus.status}</strong>
-            {personParcelControl.onChangeStatus.isPending && <button onClick={rejectRef.current}>reject</button>}
+        <p>Request state: <strong>{personParcelControl.submitStatus.status}</strong>
+            {personParcelControl.submitStatus.isPending && <button onClick={rejectRef.current}>reject</button>}
         </p>
     </div>);
 }

--- a/packages/dataparcels-docs/src/examples/SubmitButtonOnChangeClear.jsx
+++ b/packages/dataparcels-docs/src/examples/SubmitButtonOnChangeClear.jsx
@@ -25,11 +25,11 @@ export default function SignUpForm(props) {
 
     let [personParcel, personParcelControl] = useParcelForm({
         value: initialValue,
-        onChange: async (parcel) => {
+        onSubmit: async (parcel) => {
             await saveMyData(parcel.value);
             return initialValue;
         },
-        onChangeUseResult: true
+        onSubmitUseResult: true
     });
 
     let personParcelState = personParcelControl._outerParcel;
@@ -46,8 +46,8 @@ export default function SignUpForm(props) {
 
         <button onClick={() => personParcelControl.submit()}>Submit</button>
 
-        <p>Request state: <strong>{personParcelControl.onChangeStatus.status}</strong>
-            {personParcelControl.onChangeStatus.isPending && <button onClick={rejectRef.current}>reject</button>}
+        <p>Request state: <strong>{personParcelControl.submitStatus.status}</strong>
+            {personParcelControl.submitStatus.isPending && <button onClick={rejectRef.current}>reject</button>}
         </p>
     </div>);
 }

--- a/packages/dataparcels-docs/src/examples/SubmitButtonOnChangeClearSource.txt
+++ b/packages/dataparcels-docs/src/examples/SubmitButtonOnChangeClearSource.txt
@@ -11,11 +11,11 @@ export default function SignUpForm(props) {
 
     let [personParcel, personParcelControl] = useParcelForm({
         value: initialValue,
-        onChange: async (parcel) => {
+        onSubmit: async (parcel) => {
             await saveMyData(parcel.value);
             return initialValue;
         },
-        onChangeUseResult: true
+        onSubmitUseResult: true
     });
 
     return <div>

--- a/packages/dataparcels-docs/src/examples/SubmitButtonOnChangeLoad.jsx
+++ b/packages/dataparcels-docs/src/examples/SubmitButtonOnChangeLoad.jsx
@@ -32,8 +32,8 @@ export default function PersonEditor(props) {
 
     let [personParcel, personParcelControl] = useParcelForm({
         value: initialValue,
-        onChange: (parcel) => saveMyData(parcel.value),
-        onChangeUseResult: true
+        onSubmit: (parcel) => saveMyData(parcel.value),
+        onSubmitUseResult: true
     });
 
     let {timeUpdated} = personParcel.value;
@@ -54,8 +54,8 @@ export default function PersonEditor(props) {
 
         <button onClick={() => personParcelControl.submit()}>Submit</button>
 
-        <p>Request state: <strong>{personParcelControl.onChangeStatus.status}</strong>
-            {personParcelControl.onChangeStatus.isPending && <button onClick={rejectRef.current}>reject</button>}
+        <p>Request state: <strong>{personParcelControl.submitStatus.status}</strong>
+            {personParcelControl.submitStatus.isPending && <button onClick={rejectRef.current}>reject</button>}
         </p>
     </div>);
 }

--- a/packages/dataparcels-docs/src/examples/SubmitButtonOnChangeLoadSource.txt
+++ b/packages/dataparcels-docs/src/examples/SubmitButtonOnChangeLoadSource.txt
@@ -6,8 +6,8 @@ export default function PersonEditor(props) {
 
     let [personParcel, personParcelControl] = useParcelForm({
         value: props.valueLoadedFromServer,
-        onChange: (parcel) => saveMyData(parcel.value),
-        onChangeUseResult: true
+        onSubmit: (parcel) => saveMyData(parcel.value),
+        onSubmitUseResult: true
     });
 
     let {timeUpdated} = personParcel.value;

--- a/packages/dataparcels-docs/src/examples/SubmitButtonOnChangeReduxSource.txt
+++ b/packages/dataparcels-docs/src/examples/SubmitButtonOnChangeReduxSource.txt
@@ -7,7 +7,7 @@ export default function PersonEditor(props) {
     let [personParcel, personParcelControl] = useParcelForm({
         value: props.personData,
         updateValue: true,
-        onChange: (parcel) => props.dispatchMySaveAction(parcel.value)
+        onSubmit: (parcel) => props.dispatchMySaveAction(parcel.value)
     });
 
     // ^ dispatchMySaveAction should return a promise if it is

--- a/packages/dataparcels-docs/src/examples/SubmitButtonOnChangeSource.txt
+++ b/packages/dataparcels-docs/src/examples/SubmitButtonOnChangeSource.txt
@@ -11,7 +11,7 @@ export default function SignUpForm(props) {
 
     let [personParcel, personParcelControl] = useParcelForm({
         value: initialValue,
-        onChange: (parcel) => saveMyData(parcel.value)
+        onSubmit: (parcel) => saveMyData(parcel.value)
         // ^ returns a promise
     });
 

--- a/packages/dataparcels-docs/src/pages/api/useParcelForm.jsx
+++ b/packages/dataparcels-docs/src/pages/api/useParcelForm.jsx
@@ -12,8 +12,8 @@ export default () => <Layout>
             '# Params',
             'value',
             'updateValue',
-            'onChange',
-            'onChangeUseResult',
+            'onSubmit',
+            'onSubmitUseResult',
             'buffer',
             'debounce',
             'validation',
@@ -21,7 +21,8 @@ export default () => <Layout>
             '# Returns',
             'parcel',
             'parcelControl',
-            '# ParcelHookControl'
+            '# ParcelHookControl',
+            '# Inside the hook'
         ]}
     />
 </Layout>;

--- a/packages/dataparcels-docs/src/pages/api/useParcelForm.mdx
+++ b/packages/dataparcels-docs/src/pages/api/useParcelForm.mdx
@@ -11,48 +11,9 @@ import ValueUpdater from 'docs/notes/ValueUpdater.md';
 
 <ApiPageIcon>{Icon}</ApiPageIcon>
 
-The useParcelForm function is a React hook. Its job is to make submittable forms easy to build, by combining [useParcelState](/api/useParcelState) and [useParcelBuffer](/api/useParcelBuffer) together.
+The useParcelForm function is a React hook. Its job is to make submittable forms easy to build. It provides a parcel stored in state and an internal buffer to store unsaved changes, and also handles how the parcel responds to changes in React props.
 
-This is perfect for creating user interfaces that can show data that's fetched from a server, allow it to be edited by the user, and then send any changes back to the server.
-
-The useParcelForm hook holds two Parcels in state:
-1. the original data provided via `value`, hereby known as "outerParcel"
-2. a buffered version of the same Parcel that contains the user's active changes, hereby known as "innerParcel"
-
-The hook looks roughly like this:
-
-```js
-// 1. Parcel State
-//
-// holds the original data
-// and sends changed data to a callback
-let [outerParcel] = useParcelState({
-    value,
-    updateValue
-});
-
-// ...some magic related to the onChange function...
-
-// 2. Parcel Buffer
-//
-// buffers the changes that the user has made
-// and prevents those changes from being propagated
-// back up to state until its ready to be saved
-let [innerParcel, parcelControl] = useParcelBuffer({
-    parcel: outerParcel,
-    buffer,
-    debounce,
-    beforeChange
-});
-
-// 3. Outside of the useParcelForm hook...
-// allow the user to make changes to the data
-innerParcel.get('...') // etc
-
-parcelControl.submit(); // or just use debounce
-```
-
-Using this pattern, the "submit" button is really an action that instructs the useParcelBuffer hook to release all of its buffered changes up into the useParcelState hook.
+This is perfect for creating user interfaces that allow the user to edit data and send changes back to the server.
 
 ```js
 import useParcelForm from 'react-dataparcels/useParcelForm';
@@ -63,14 +24,26 @@ let [parcel] = useParcelForm({
     value: any,
     // optional
     updateValue?: boolean,
-    onChange?: Function,
-    onChangeUseResult?: boolean,
+    onSubmit?: Function,
+    onSubmitUseResult?: boolean,
     buffer?: boolean,
     debounce?: number,
     validation?: Function,
     beforeChange?: Function|Function[]
 });
 ```
+
+The explanations on this page sometimes refer to an "outerParcel" and an "innerParcel". This is because the useParcelForm hook actually holds two Parcels in state:
+
+#### outerParcel
+
+The original data provided via `value`. This parcel updates less frequently than innerParcel, only updating when the form is submitted, or if it is instructed to receive a new value via props or via the `onSubmit` function.
+
+#### innerParcel
+
+A parcel that sits downstream of outerParcel, acting as a buffer to hold on to unsaved changes. It updates each time the user changes the form, or as a result of outerParcel updating.
+
+If you're interested you can [read more about what's inside the hook](#Inside-the-hook).
 
 <Break />
 
@@ -136,10 +109,10 @@ parcel.set(200);
 // then parcel.value is now 300
 ```
 
-### onChange
+### onSubmit
 
 ```flow
-onChange?: (parcel: Parcel, changeRequest: ChangeRequest) => any|Promise<any> // optional
+onSubmit?: (parcel: Parcel, changeRequest: ChangeRequest) => any|Promise<any> // optional
 ```
 
 If provided, this function is called after innerParcel releases the contents of its buffer and propagates its changes, but before outerParcel's state is updated. It receives the new [Parcel](/api/Parcel), and the [ChangeRequest](/api/ChangeRequest) that was responsible for the change. This function can be used to relay changes further up the React heirarchy.
@@ -147,42 +120,42 @@ If provided, this function is called after innerParcel releases the contents of 
 ```js
 let [parcel] = useParcelForm({
     value: receivedValue,
-    onChange: (parcel, changeRequest) => {
+    onSubmit: (parcel, changeRequest) => {
         // add logic here
     }
 });
 ```
 
-#### onChange with promises
+#### onSubmit with promises
 
-It's possible to return a promise from `onChange`. When doing this, the ChangeRequest's propagation is halted and is only released once the promise resolves, at which point outerParcel's state will be updated to contain the new Parcel.
+It's possible to return a promise from `onSubmit`. When doing this, the ChangeRequest's propagation is halted and is only released once the promise resolves, at which point outerParcel's state will be updated to contain the new Parcel.
 
-If another change arrives while a promise is pending, it will be passed through `onChange` after the first promise is resolved or rejected. This is to ensure that there is only one operation happening at a time. If the first ChangeRequest's
-promise is rejected, the changes will be merged with the next ChangeRequest when `onChange` is called the second time.
+If another change arrives while a promise is pending, it will be passed through `onSubmit` after the first promise is resolved or rejected. This is to ensure that there is only one operation happening at a time. If the first ChangeRequest's
+promise is rejected, the changes will be merged with the next ChangeRequest when `onSubmit` is called the second time.
 
 This is discussed in more detail in [data synchronisation](/data-synchronisation).
 
-*Please keep in mind that it is possible for a change to result in the same data being contained in the Parcel, `onChange` will not dedupe subsequent calls whose Parcels contain the same data.*
+*Please keep in mind that it is possible for a change to result in the same data being contained in the Parcel, `onSubmit` will not dedupe subsequent calls whose Parcels contain the same data.*
 
-### onChangeUseResult
+### onSubmitUseResult
 
 ```flow
-onChangeUseResult?: boolean = false // optional
+onSubmitUseResult?: boolean = false // optional
 ```
 
-When true, this sets the value of the outerParcel to the return value of `onChange`. If `onChange` returns a promise, the resolved value of the promise will be used.
+When true, this sets the value of the outerParcel to the return value of `onSubmit`. If `onSubmit` returns a promise, the resolved value of the promise will be used.
 
-Using `onChangeUseResult` can be useful for receiving data back from a request to write data to a server, as it ensures that outerParcel's value is as up-to-date as possible. This is discussed in more detail in [data synchronisation](/data-synchronisation#Receiving-data-from-the-server-after-saving).
+Using `onSubmitUseResult` can be useful for receiving data back from a request to write data to a server, as it ensures that outerParcel's value is as up-to-date as possible. This is discussed in more detail in [data synchronisation](/data-synchronisation#Receiving-data-from-the-server-after-saving).
 
 ```js
 let [parcel] = useParcelForm({
     value: receivedValue,
-    onChange: (parcel, changeRequest) => {
+    onSubmit: (parcel, changeRequest) => {
         return saveMyData(parcel.value);
         // ^ saveMyData send a request to a server to save the data,
         // and returns a promise containing the updated data from the server
     },
-    onChangeUseResult: true
+    onSubmitUseResult: true
 });
 ```
 
@@ -215,7 +188,7 @@ The useParcelForm hooks waits until no new changes have occured for `debounce` n
 ```js
 let [parcel] = useParcelForm({
     value: receivedValue,
-    onChange: (parcel, changeRequest) => {
+    onSubmit: (parcel, changeRequest) => {
         // add logic here
     },
     debounce: 500
@@ -322,7 +295,7 @@ type ParcelHookControl {
     reset: Function,
     buffered: boolean,
     actions: Action[],
-    onChangeStatus: {
+    submitStatus: {
         status: string
         pending: boolean,
         error: any
@@ -342,26 +315,71 @@ type ParcelHookControl {
 * <Param name="actions" type="Action[]" />
   An array of actions that are currently in the buffer.
 
-* <Param name="onChangeStatus" type="Object" />
-  An object containing information about the current state of the execution of the `onChange` function. This is useful if you're using promises with `onChange` and want to conditionally render elements based on the state of the promise.
+* <Param name="submitStatus" type="Object" />
+  An object containing information about the current state of the execution of the `onSubmit` function. This is useful if you're using promises with `onSubmit` and want to conditionally render elements based on the state of the promise.
 
   * <Param name="status" type="string" />
     Status is always one of four possible string values:
 
-    * `"idle"` - no promises have yet been returned from `onChange`
-    * `"pending"` - if `onChange` returned a promise and that promise is pending.
-    * `"resolved"` - if the last promise returned from `onChange` was resolved.
-    * `"rejected"` - if the last promise returned from `onChange` was rejected.
+    * `"idle"` - no promises have yet been returned from `onSubmit`
+    * `"pending"` - if `onSubmit` returned a promise and that promise is pending.
+    * `"resolved"` - if the last promise returned from `onSubmit` was resolved.
+    * `"rejected"` - if the last promise returned from `onSubmit` was rejected.
 
   * <Param name="isPending" type="boolean" />
-    The `isPending` boolean is true if `onChange` returned a promise and that promise is pending, otherwise it is false.
+    The `isPending` boolean is true if `onSubmit` returned a promise and that promise is pending, otherwise it is false.
 
   * <Param name="isResolved" type="boolean" />
-    The `isResolved` boolean is true if the last promise returned from `onChange` was resolved.
+    The `isResolved` boolean is true if the last promise returned from `onSubmit` was resolved.
 
   * <Param name="isRejected" type="boolean" />
-    The `isRejected` boolean is true if the last promise returned from `onChange` was rejected.
+    The `isRejected` boolean is true if the last promise returned from `onSubmit` was rejected.
 
   * <Param name="error" type="any" />
-    If the last promise returned from `onChange` was rejected, this contains the rejected promise's payload.
+    If the last promise returned from `onSubmit` was rejected, this contains the rejected promise's payload.
 
+## Inside the hook
+
+The useParcelForm hook is a combination of [useParcelState](/api/useParcelState) and [useParcelBuffer](/api/useParcelBuffer).
+
+Internally, the hook looks roughly like this:
+
+```js
+
+useParcelForm = (hookConfig) => {
+
+    // 1. Parcel State
+    //
+    // holds the original data
+    // and sends changed data to a callback
+    let [outerParcel] = useParcelState({
+        value,
+        updateValue
+    });
+
+    // ...some magic related to the onSubmit function...
+
+    // 2. Parcel Buffer
+    //
+    // buffers the changes that the user has made
+    // and prevents those changes from being propagated
+    // back up to state until its ready to be saved
+    let [innerParcel, parcelControl] = useParcelBuffer({
+        parcel: outerParcel,
+        buffer,
+        debounce,
+        beforeChange
+    });
+
+    return [innerParcel, parcelControl];
+}
+
+// 3. Outside of the useParcelForm hook
+// allow the user to make changes to the data
+let [innerParcel, parcelControl] = useParcelForm(...);
+
+innerParcel.get('...') // etc
+parcelControl.submit();
+```
+
+The "submit" button is really an action that instructs the useParcelBuffer hook to release all of its buffered changes up into the useParcelState hook.

--- a/packages/dataparcels-docs/src/pages/data-synchronisation.mdx
+++ b/packages/dataparcels-docs/src/pages/data-synchronisation.mdx
@@ -26,7 +26,7 @@ This example makes use of the [useParcelForm](/api/useParcelForm) hook. This is 
 
 ## Clearing a form after submit
 
-You can set the data in the form to something else after it's sent its data by setting [onChangeUseResult](/api/useParcelForm#onChangeUseResult) to true. The form's current state will be replaced by whatever returned from `onChange`.
+You can set the data in the form to something else after it's sent its data by setting [onSubmitUseResult](/api/useParcelForm#onSubmitUseResult) to true. The form's current state will be replaced by whatever returned from `onSubmit`.
 
 <SubmitButtonOnChangeClear />
 <Code language="jsx">{SubmitButtonOnChangeClearSource}</Code>
@@ -46,7 +46,7 @@ If you're using something like [Redux](https://redux.js.org/), you'll likely be 
 
 ### Updating form data via a promise
 
-You may not have centralised state management like Redux in your app. In this case you can get useParcelForm to update based off the return value of the promise returned by the save function. To use this approach, set the [onChangeUseResult](/api/useParcelForm#onChangeUseResult) parameter to true.
+You may not have centralised state management like Redux in your app. In this case you can get useParcelForm to update based off the return value of the promise returned by the save function. To use this approach, set the [onSubmitUseResult](/api/useParcelForm#onSubmitUseResult) parameter to true.
 
 <SubmitButtonOnChangeLoad />
 <Code language="jsx">{SubmitButtonOnChangeLoadSource}</Code>

--- a/packages/dataparcels-docs/src/shape/ContentNav.jsx
+++ b/packages/dataparcels-docs/src/shape/ContentNav.jsx
@@ -15,9 +15,8 @@ const nav = () => <NavigationList>
     <NavigationListItem modifier="section">API</NavigationListItem>
     <NavigationListItem><Link to="/api/Parcel">Parcel</Link></NavigationListItem>
     <NavigationListItem><Link to="/api/ParcelBoundary">ParcelBoundary</Link></NavigationListItem>
-    <NavigationListItem><Link to="/api/useParcelState">useParcelState</Link></NavigationListItem>
     <NavigationListItem><Link to="/api/useParcelForm">useParcelForm</Link></NavigationListItem>
-    <NavigationListItem><Link to="/api/useParcelBuffer">useParcelBuffer</Link></NavigationListItem>
+    <NavigationListItem><Link to="/api/useParcelState">useParcelState</Link></NavigationListItem>
     <NavigationListItem><Link to="/api/validation">validation</Link></NavigationListItem>
     <NavigationListItem><Link to="/api/ParcelDrag">ParcelDrag</Link></NavigationListItem>
     <NavigationListItem><Link to="/api">more...</Link></NavigationListItem>

--- a/packages/dataparcels-docs/yalc.lock
+++ b/packages/dataparcels-docs/yalc.lock
@@ -2,7 +2,7 @@
   "version": "v1",
   "packages": {
     "react-dataparcels": {
-      "signature": "d4b85df241289d4830108fcb27e75b96",
+      "signature": "399c419dd23445b15c9a03b7fcae9341",
       "file": true,
       "replaced": "^0.21.0"
     },

--- a/packages/dataparcels-docs/yarn.lock
+++ b/packages/dataparcels-docs/yarn.lock
@@ -3597,10 +3597,10 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
-dataparcels@^0.22.0:
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/dataparcels/-/dataparcels-0.22.0.tgz#386ad3b072970bc1f5db77fbdaf7d6b1c5fc8e78"
-  integrity sha512-8LEBB0hVHUwvuDSM3e/ybWiKqZoO8AfiLx7h41f58Ov+pZ7ia+1RCcNNm0+qq1VIK/E7QAYphN8Rybb0iJPyDA==
+dataparcels@^0.23.0:
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/dataparcels/-/dataparcels-0.23.0.tgz#da9e5f4075906f9ea6540ea94130e6ab93746b92"
+  integrity sha512-hw7K+aTTJzPZmkfU+Ct2W+yyH6092t3bXoQ9p8fSQfAsEEAuiBSUU4eHxlqCOdb7z6wrVXWoLya5/WnA3St3rA==
   dependencies:
     "@babel/runtime" "^7.1.5"
     unmutable "^0.41.1"
@@ -9688,16 +9688,16 @@ react-cool-storage@^0.1.1:
     unmutable "^0.39.0"
 
 "react-dataparcels-drag@file:.yalc/react-dataparcels-drag":
-  version "0.22.0-b07beb78"
+  version "0.23.0-2bbfb62a"
   dependencies:
     "@babel/runtime" "^7.1.5"
     react-sortable-hoc "1.4.0"
 
 "react-dataparcels@file:.yalc/react-dataparcels":
-  version "0.22.0-c304f58a"
+  version "0.23.0-640ebd29"
   dependencies:
     "@babel/runtime" "^7.1.5"
-    dataparcels "^0.22.0"
+    dataparcels "^0.23.0"
     is-promise "^2.1.0"
     unmutable "^0.41.1"
     use-debounce "^1.1.3"

--- a/packages/react-dataparcels/src/__test__/useParcelForm-test.js
+++ b/packages/react-dataparcels/src/__test__/useParcelForm-test.js
@@ -24,7 +24,7 @@ describe('useParcelForm should pass config to useParcelState', () => {
 
         expect(calledWith.value).toBe(123);
         expect(calledWith.updateValue).toBe(false);
-        expect(calledWith.onChange).toBe(undefined);
+        expect(calledWith.onSubmit).toBe(undefined);
     });
 
     it('should pass updateValue to useParcelState', () => {
@@ -47,28 +47,28 @@ describe('useParcelForm should pass config to useParcelSideEffect', () => {
         }));
 
         expect(getLastCall(useParcelSideEffect)[0].parcel).toBe(getLastResult(useParcelState)[0]);
-        expect(getLastCall(useParcelSideEffect)[0].onChangeUseResult).toBe(false);
+        expect(getLastCall(useParcelSideEffect)[0].onSubmitUseResult).toBe(false);
     });
 
-    it('should pass onChange to useParcelSideEffect', () => {
-        let onChange = () => {};
+    it('should pass onSubmit to useParcelSideEffect', () => {
+        let onSubmit = () => {};
 
         renderHook(() => useParcelForm({
             value: 123,
-            onChange
+            onSubmit
         }));
 
-        expect(getLastCall(useParcelSideEffect)[0].onChange).toBe(onChange);
+        expect(getLastCall(useParcelSideEffect)[0].onSubmit).toBe(onSubmit);
     });
 
-    it('should pass onChangeUseResult to useParcelSideEffect', () => {
+    it('should pass onSubmitUseResult to useParcelSideEffect', () => {
 
         renderHook(() => useParcelForm({
             value: 123,
-            onChangeUseResult: true
+            onSubmitUseResult: true
         }));
 
-        expect(getLastCall(useParcelSideEffect)[0].onChangeUseResult).toBe(true);
+        expect(getLastCall(useParcelSideEffect)[0].onSubmitUseResult).toBe(true);
     });
 
 });

--- a/packages/react-dataparcels/src/__test__/useParcelFormRevert-test.js
+++ b/packages/react-dataparcels/src/__test__/useParcelFormRevert-test.js
@@ -6,7 +6,7 @@ import useParcelForm from '../useParcelForm';
 
 describe('useParcelForm should revert change request', () => {
 
-    it('should put changes back into buffer from rejected onChange', async () => {
+    it('should put changes back into buffer from rejected onSubmit', async () => {
         let rejectMyPromise;
         let promise = new Promise((resolve, reject) => {
             rejectMyPromise = () => {
@@ -17,7 +17,7 @@ describe('useParcelForm should revert change request', () => {
 
         let {result} = renderHook(() => useParcelForm({
             value: [],
-            onChange: () => promise
+            onSubmit: () => promise
         }));
 
         act(() => {
@@ -42,7 +42,7 @@ describe('useParcelForm should revert change request', () => {
         expect(result.current[1].actions[0]).toBe(firstAction);
     });
 
-    it('should put changes back into buffer from rejected onChange, onto new changes', async () => {
+    it('should put changes back into buffer from rejected onSubmit, onto new changes', async () => {
         let rejectMyPromise;
         let promise = new Promise((resolve, reject) => {
             rejectMyPromise = () => {
@@ -53,7 +53,7 @@ describe('useParcelForm should revert change request', () => {
 
         let {result} = renderHook(() => useParcelForm({
             value: [],
-            onChange: () => promise
+            onSubmit: () => promise
         }));
 
         act(() => {

--- a/packages/react-dataparcels/src/__test__/useParcelSideEffect-test.js
+++ b/packages/react-dataparcels/src/__test__/useParcelSideEffect-test.js
@@ -2,12 +2,11 @@
 import {act} from 'react-hooks-testing-library';
 import {renderHook} from 'react-hooks-testing-library';
 import useParcelSideEffect from '../useParcelSideEffect';
-import useParcelBuffer from '../useParcelBuffer';
 import Parcel from 'dataparcels';
 
 const renderHookWithProps = (initialProps, callback) => renderHook(callback, {initialProps});
 
-const onChangePromise = (onChange, index = 0) => onChange.mock.results[index].value.catch(() => {});
+const onSubmitPromise = (onSubmit, index = 0) => onSubmit.mock.results[index].value.catch(() => {});
 
 describe('useParcelSideEffect should use config.parcel', () => {
 
@@ -91,11 +90,11 @@ describe('useParcelSideEffect should use config.parcel', () => {
 
 });
 
-describe('useParcelSideEffect should use config.onChange', () => {
+describe('useParcelSideEffect should use config.onSubmit', () => {
 
-    it('should call onChange with value and change request if provided', () => {
+    it('should call onSubmit with value and change request if provided', () => {
         let handleChange = jest.fn();
-        let onChange = jest.fn();
+        let onSubmit = jest.fn();
 
         let parcel = new Parcel({
             value: 123,
@@ -104,22 +103,22 @@ describe('useParcelSideEffect should use config.onChange', () => {
 
         let {result} = renderHook(() => useParcelSideEffect({
             parcel,
-            onChange
+            onSubmit
         }));
 
         act(() => {
             result.current[0].set(456);
         });
 
-        expect(onChange).toHaveBeenCalledTimes(1);
-        expect(onChange.mock.calls[0][0].value).toBe(456);
-        expect(onChange.mock.calls[0][1].prevData.value).toBe(123);
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+        expect(onSubmit.mock.calls[0][0].value).toBe(456);
+        expect(onSubmit.mock.calls[0][1].prevData.value).toBe(123);
         expect(handleChange.mock.calls[0][0].value).toBe(456);
     });
 
-    it('should call onChange with result if onChangeUseResult = true', () => {
+    it('should call onSubmit with result if onSubmitUseResult = true', () => {
         let handleChange = jest.fn();
-        let onChange = jest.fn(() => 333);
+        let onSubmit = jest.fn(() => 333);
 
         let parcel = new Parcel({
             value: [123],
@@ -128,30 +127,30 @@ describe('useParcelSideEffect should use config.onChange', () => {
 
         let {result} = renderHook(() => useParcelSideEffect({
             parcel,
-            onChange,
-            onChangeUseResult: true
+            onSubmit,
+            onSubmitUseResult: true
         }));
 
         act(() => {
             result.current[0].get(0).set(456);
         });
 
-        expect(onChange).toHaveBeenCalledTimes(1);
-        expect(onChange.mock.calls[0][0].value).toEqual([456]);
-        expect(onChange.mock.calls[0][1].prevData.value).toEqual([123]);
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+        expect(onSubmit.mock.calls[0][0].value).toEqual([456]);
+        expect(onSubmit.mock.calls[0][1].prevData.value).toEqual([123]);
         expect(handleChange.mock.calls[0][0].value).toEqual(333);
-        expect(handleChange.mock.calls[0][1].originId).toBe(onChange.mock.calls[0][1].originId);
+        expect(handleChange.mock.calls[0][1].originId).toBe(onSubmit.mock.calls[0][1].originId);
     });
 
 });
 
 
-describe('useParcelSideEffect should use config.onChange with promises', () => {
+describe('useParcelSideEffect should use config.onSubmit with promises', () => {
 
-    it('should default to a default onChangeStatus', async () => {
+    it('should default to a default submitStatus', async () => {
 
         let handleChange = jest.fn();
-        let onChange = jest.fn(() => Promise.resolve(333));
+        let onSubmit = jest.fn(() => Promise.resolve(333));
 
         let parcel = new Parcel({
             value: 123,
@@ -160,11 +159,11 @@ describe('useParcelSideEffect should use config.onChange with promises', () => {
 
         let {result} = renderHook(() => useParcelSideEffect({
             parcel,
-            onChange
+            onSubmit
         }));
 
         expect(result.current[1]).toEqual({
-            onChangeStatus: {
+            submitStatus: {
                 status: 'idle',
                 isPending: false,
                 isResolved: false,
@@ -176,9 +175,9 @@ describe('useParcelSideEffect should use config.onChange with promises', () => {
     });
 
 
-    it('should call onChange with promise that resolves', async () => {
+    it('should call onSubmit with promise that resolves', async () => {
         let handleChange = jest.fn();
-        let onChange = jest.fn(() => Promise.resolve(333));
+        let onSubmit = jest.fn(() => Promise.resolve(333));
 
         let parcel = new Parcel({
             value: 123,
@@ -187,20 +186,20 @@ describe('useParcelSideEffect should use config.onChange with promises', () => {
 
         let {result} = renderHook(() => useParcelSideEffect({
             parcel,
-            onChange
+            onSubmit
         }));
 
         act(() => {
             result.current[0].set(456);
         });
 
-        expect(onChange).toHaveBeenCalledTimes(1);
-        expect(onChange.mock.calls[0][0].value).toBe(456);
-        expect(onChange.mock.calls[0][1].prevData.value).toBe(123);
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+        expect(onSubmit.mock.calls[0][0].value).toBe(456);
+        expect(onSubmit.mock.calls[0][1].prevData.value).toBe(123);
         expect(handleChange).toHaveBeenCalledTimes(0);
 
         await act(async () => {
-            await onChangePromise(onChange);
+            await onSubmitPromise(onSubmit);
         });
 
         expect(handleChange).toHaveBeenCalledTimes(1);
@@ -208,7 +207,7 @@ describe('useParcelSideEffect should use config.onChange with promises', () => {
     });
 
     it('should set status correctly with promise that resolves', async () => {
-        let onChange = jest.fn(() => Promise.resolve(333));
+        let onSubmit = jest.fn(() => Promise.resolve(333));
 
         let parcel = new Parcel({
             value: 123
@@ -216,7 +215,7 @@ describe('useParcelSideEffect should use config.onChange with promises', () => {
 
         let {result} = renderHook(() => useParcelSideEffect({
             parcel,
-            onChange
+            onSubmit
         }));
 
         act(() => {
@@ -224,7 +223,7 @@ describe('useParcelSideEffect should use config.onChange with promises', () => {
         });
 
         expect(result.current[1]).toEqual({
-            onChangeStatus: {
+            submitStatus: {
                 status: 'pending',
                 isPending: true,
                 isResolved: false,
@@ -234,11 +233,11 @@ describe('useParcelSideEffect should use config.onChange with promises', () => {
         });
 
         await act(async () => {
-            await onChangePromise(onChange);
+            await onSubmitPromise(onSubmit);
         });
 
         expect(result.current[1]).toEqual({
-            onChangeStatus: {
+            submitStatus: {
                 status: 'resolved',
                 isPending: false,
                 isResolved: true,
@@ -248,9 +247,9 @@ describe('useParcelSideEffect should use config.onChange with promises', () => {
         });
     });
 
-    it('should not call onChange with promise that rejects', async () => {
+    it('should not call onSubmit with promise that rejects', async () => {
         let handleChange = jest.fn();
-        let onChange = jest.fn(() => Promise.reject('error message!'));
+        let onSubmit = jest.fn(() => Promise.reject('error message!'));
 
         let parcel = new Parcel({
             value: 123,
@@ -259,20 +258,20 @@ describe('useParcelSideEffect should use config.onChange with promises', () => {
 
         let {result} = renderHook(() => useParcelSideEffect({
             parcel,
-            onChange
+            onSubmit
         }));
 
         act(() => {
             result.current[0].set(456);
         });
 
-        expect(onChange).toHaveBeenCalledTimes(1);
-        expect(onChange.mock.calls[0][0].value).toBe(456);
-        expect(onChange.mock.calls[0][1].prevData.value).toBe(123);
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+        expect(onSubmit.mock.calls[0][0].value).toBe(456);
+        expect(onSubmit.mock.calls[0][1].prevData.value).toBe(123);
         expect(handleChange).toHaveBeenCalledTimes(0);
 
         await act(async () => {
-            await onChangePromise(onChange);
+            await onSubmitPromise(onSubmit);
         });
 
         expect(handleChange).toHaveBeenCalledTimes(0);
@@ -280,7 +279,7 @@ describe('useParcelSideEffect should use config.onChange with promises', () => {
     });
 
     it('should set status correctly with promise that rejects', async () => {
-        let onChange = jest.fn(() => Promise.reject('error message!'));
+        let onSubmit = jest.fn(() => Promise.reject('error message!'));
 
         let parcel = new Parcel({
             value: 123
@@ -288,7 +287,7 @@ describe('useParcelSideEffect should use config.onChange with promises', () => {
 
         let {result} = renderHook(() => useParcelSideEffect({
             parcel,
-            onChange
+            onSubmit
         }));
 
         act(() => {
@@ -296,11 +295,11 @@ describe('useParcelSideEffect should use config.onChange with promises', () => {
         });
 
         await act(async () => {
-            await onChangePromise(onChange);
+            await onSubmitPromise(onSubmit);
         });
 
         expect(result.current[1]).toEqual({
-            onChangeStatus: {
+            submitStatus: {
                 status: 'rejected',
                 isPending: false,
                 isResolved: false,
@@ -310,9 +309,9 @@ describe('useParcelSideEffect should use config.onChange with promises', () => {
         });
     });
 
-    it('should call onChange with promise that resolves with result if onChangeUseResult = true', async () => {
+    it('should call onSubmit with promise that resolves with result if onSubmitUseResult = true', async () => {
         let handleChange = jest.fn();
-        let onChange = jest.fn(() => Promise.resolve(333));
+        let onSubmit = jest.fn(() => Promise.resolve(333));
 
         let parcel = new Parcel({
             value: 123,
@@ -321,31 +320,31 @@ describe('useParcelSideEffect should use config.onChange with promises', () => {
 
         let {result} = renderHook(() => useParcelSideEffect({
             parcel,
-            onChange,
-            onChangeUseResult: true
+            onSubmit,
+            onSubmitUseResult: true
         }));
 
         act(() => {
             result.current[0].set(456);
         });
 
-        expect(onChange).toHaveBeenCalledTimes(1);
-        expect(onChange.mock.calls[0][0].value).toBe(456);
-        expect(onChange.mock.calls[0][1].prevData.value).toBe(123);
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+        expect(onSubmit.mock.calls[0][0].value).toBe(456);
+        expect(onSubmit.mock.calls[0][1].prevData.value).toBe(123);
         expect(handleChange).toHaveBeenCalledTimes(0);
 
         await act(async () => {
-            await onChangePromise(onChange);
+            await onSubmitPromise(onSubmit);
         });
 
         expect(handleChange).toHaveBeenCalledTimes(1);
         expect(handleChange.mock.calls[0][0].value).toBe(333);
     });
 
-    it('should merge subsequent onChange if promise resolves twice', async () => {
+    it('should merge subsequent onSubmit if promise resolves twice', async () => {
         let handleChange = jest.fn();
-        let onChange = jest.fn();
-        onChange
+        let onSubmit = jest.fn();
+        onSubmit
             .mockReturnValueOnce(Promise.resolve())
             .mockReturnValueOnce(Promise.resolve());
 
@@ -356,7 +355,7 @@ describe('useParcelSideEffect should use config.onChange with promises', () => {
 
         let {result} = renderHook(() => useParcelSideEffect({
             parcel,
-            onChange
+            onSubmit
         }));
 
         act(() => {
@@ -365,28 +364,28 @@ describe('useParcelSideEffect should use config.onChange with promises', () => {
         });
 
         // only process one change at a time...
-        expect(onChange).toHaveBeenCalledTimes(1);
-        expect(onChange.mock.calls[0][0].value).toEqual([123]);
-        expect(onChange.mock.calls[0][1].prevData.value).toEqual([]);
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+        expect(onSubmit.mock.calls[0][0].value).toEqual([123]);
+        expect(onSubmit.mock.calls[0][1].prevData.value).toEqual([]);
 
         // wait until the first promise is complete before firing off anything
         expect(handleChange).toHaveBeenCalledTimes(0);
 
         await act(async () => {
-            await onChangePromise(onChange);
+            await onSubmitPromise(onSubmit);
         });
 
-        expect(onChange).toHaveBeenCalledTimes(2);
-        expect(onChange.mock.calls[1][0].value).toEqual([123, 456]);
-        expect(onChange.mock.calls[1][1].prevData.value).toEqual([]);
+        expect(onSubmit).toHaveBeenCalledTimes(2);
+        expect(onSubmit.mock.calls[1][0].value).toEqual([123, 456]);
+        expect(onSubmit.mock.calls[1][1].prevData.value).toEqual([]);
         expect(handleChange).toHaveBeenCalledTimes(1);
         expect(handleChange.mock.calls[0][0].value).toEqual([123, 456]);
     });
 
-    it('should merge subsequent onChange if promise rejects and then resolves', async () => {
+    it('should merge subsequent onSubmit if promise rejects and then resolves', async () => {
         let handleChange = jest.fn();
-        let onChange = jest.fn();
-        onChange
+        let onSubmit = jest.fn();
+        onSubmit
             .mockReturnValueOnce(Promise.reject())
             .mockReturnValueOnce(Promise.resolve());
 
@@ -397,7 +396,7 @@ describe('useParcelSideEffect should use config.onChange with promises', () => {
 
         let {result} = renderHook(() => useParcelSideEffect({
             parcel,
-            onChange
+            onSubmit
         }));
 
         act(() => {
@@ -406,20 +405,20 @@ describe('useParcelSideEffect should use config.onChange with promises', () => {
         });
 
         // only process one change at a time...
-        expect(onChange).toHaveBeenCalledTimes(1);
-        expect(onChange.mock.calls[0][0].value).toEqual([123]);
-        expect(onChange.mock.calls[0][1].prevData.value).toEqual([]);
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+        expect(onSubmit.mock.calls[0][0].value).toEqual([123]);
+        expect(onSubmit.mock.calls[0][1].prevData.value).toEqual([]);
 
         // wait until the first promise is complete before firing off anything
         expect(handleChange).toHaveBeenCalledTimes(0);
 
         await act(async () => {
-            await onChangePromise(onChange);
+            await onSubmitPromise(onSubmit);
         });
 
-        expect(onChange).toHaveBeenCalledTimes(2);
-        expect(onChange.mock.calls[1][0].value).toEqual([123, 456]);
-        expect(onChange.mock.calls[1][1].prevData.value).toEqual([]);
+        expect(onSubmit).toHaveBeenCalledTimes(2);
+        expect(onSubmit.mock.calls[1][0].value).toEqual([123, 456]);
+        expect(onSubmit.mock.calls[1][1].prevData.value).toEqual([]);
         expect(handleChange).toHaveBeenCalledTimes(1);
         expect(handleChange.mock.calls[0][0].value).toEqual([123, 456]);
     });

--- a/packages/react-dataparcels/src/useParcelForm.js
+++ b/packages/react-dataparcels/src/useParcelForm.js
@@ -14,8 +14,8 @@ import useParcelBuffer from './useParcelBuffer';
 type Params = {
     value: any,
     updateValue?: boolean,
-    onChange?: (parcel: Parcel, changeRequest: ChangeRequest) => any|Promise<any>,
-    onChangeUseResult?: boolean,
+    onSubmit?: (parcel: Parcel, changeRequest: ChangeRequest) => any|Promise<any>,
+    onSubmitUseResult?: boolean,
     buffer?: boolean,
     debounce?: number,
     validation?: ParcelValueUpdater|() => ParcelValueUpdater,
@@ -29,8 +29,8 @@ export default (params: Params): Return => {
     let {
         value,
         updateValue = false,
-        onChange,
-        onChangeUseResult = false,
+        onSubmit,
+        onSubmitUseResult = false,
         buffer = true,
         debounce = 0,
         validation,
@@ -54,8 +54,8 @@ export default (params: Params): Return => {
 
     let [sideEffectParcel, sideEffectControl] = useParcelSideEffect({
         parcel: outerParcel,
-        onChange,
-        onChangeUseResult
+        onSubmit,
+        onSubmitUseResult
     });
 
     let [innerParcel, innerParcelControl] = useParcelBuffer({


### PR DESCRIPTION
## react-dataparcels

- **BREAKING CHANGE** useParcelForm's API has had some renaming
  - `useParcelForm onChange` is now `useParcelForm onSubmit`
  - `useParcelForm onChangeUseResult` is now `useParcelForm onSubmitUseResult`
  - `useParcelForm`'s returned `onChangeStatus` is now `submitStatus`

The reason is because the action is being referred to as submit
everywhere else. Even the function that triggers the submit is
called "submit". This was called onChange, because from the point of view of
the internal useParcelState hook it is just a "change", and that variable name just flew out the window but the name should really reflect how its used