### PR TITLE
Refactor lastOriginId and add mergeMode

### DIFF
--- a/packages/dataparcels-docs/src/layout/index.scss
+++ b/packages/dataparcels-docs/src/layout/index.scss
@@ -75,6 +75,9 @@
         text-shadow: -6px 6px 0px lighten(color('primary'), 10),
             -12px 12px 0px lighten(color('primary'), 30)
     }
+    &-code {
+        overflow: auto;
+    }
 }
 @include DcmeTypography {
     input {

--- a/packages/dataparcels-docs/src/pages/index.mdx
+++ b/packages/dataparcels-docs/src/pages/index.mdx
@@ -69,9 +69,6 @@ I hope this library helps solve some front-end problems for you.
 
 ### Roadmap
 
-- Add **revertable changes**. The `useParcelState.onChange` callback should be able to return promises, and this can then allow failed `onChange` calls to reinstate unsaved changes in a lower Parcel buffer. This is a crucial feature that will allow for forms to rollback when requests fail.
-- Add **data synchronisation docs**, including data sync strategies strategies with examples.
-- Add **merge mode** to control how downward changes are accepted into `ParcelBoundary` components. This is required for rekey.
 - Add **rekey**, which enables changes via props to be merged into buffered changes (i.e. unsaved changes). This will allow multiple editors to alter the same piece of data simultaneously without overwriting. The ability to rebase unsaved changes onto updated data already exists, but rekey is required to make sense of incoming changes via props.
 - Add **cache**, an option in `useParcelBuffer` to save, reload and clear cached data. This can be used with `localStorage` or similar external storage mechanisms to retain and restore unsaved changes.
 - Add **production builds**, a proper build process that doesn't rely on minification and dead code elimination being carried out by the containing project's build process. This step will finally allow proper optimisations to reduce bundle size.

--- a/packages/dataparcels-docs/yalc.lock
+++ b/packages/dataparcels-docs/yalc.lock
@@ -2,7 +2,7 @@
   "version": "v1",
   "packages": {
     "react-dataparcels": {
-      "signature": "203b5a8de364b61c7dd93cd90bcd8f2b",
+      "signature": "99ceb87caf5949d601d2f46f6c637c4f",
       "file": true,
       "replaced": "^0.21.0"
     },

--- a/packages/dataparcels-docs/yalc.lock
+++ b/packages/dataparcels-docs/yalc.lock
@@ -2,7 +2,7 @@
   "version": "v1",
   "packages": {
     "react-dataparcels": {
-      "signature": "99ceb87caf5949d601d2f46f6c637c4f",
+      "signature": "7640a04beb7f2428153fe8382775b5e7",
       "file": true,
       "replaced": "^0.21.0"
     },

--- a/packages/dataparcels-docs/yalc.lock
+++ b/packages/dataparcels-docs/yalc.lock
@@ -2,7 +2,7 @@
   "version": "v1",
   "packages": {
     "react-dataparcels": {
-      "signature": "399c419dd23445b15c9a03b7fcae9341",
+      "signature": "203b5a8de364b61c7dd93cd90bcd8f2b",
       "file": true,
       "replaced": "^0.21.0"
     },

--- a/packages/dataparcels/src/errors/Errors.js
+++ b/packages/dataparcels/src/errors/Errors.js
@@ -5,4 +5,3 @@ export const ReducerInvalidActionError = (actionType: string) => new Error(`"${a
 export const ReducerInvalidStepError = (stepType: string) => new Error(`"${stepType}" is not a valid action step type`);
 export const ChangeRequestNoPrevDataError = () =>  new Error(`ChangeRequest data cannot be accessed before setting changeRequest.prevData`);
 export const ShapeUpdaterNonShapeChildError = () =>  new Error(`Every child value on a collection returned from a shape updater must be a ParcelShape`);
-export const ChangeAndReturnNotCalledError = () =>  new Error(`_changeAndReturn unchanged`);

--- a/packages/dataparcels/src/parcel/Parcel.js
+++ b/packages/dataparcels/src/parcel/Parcel.js
@@ -17,7 +17,6 @@ import type {ParentType} from '../types/Types';
 
 import Types from '../types/Types';
 import {ReadOnlyError} from '../errors/Errors';
-import {ChangeAndReturnNotCalledError} from '../errors/Errors';
 
 import ParcelGetMethods from './methods/ParcelGetMethods';
 import ParcelChangeMethods from './methods/ParcelChangeMethods';
@@ -188,7 +187,7 @@ export default class Parcel {
         }
     };
 
-    _changeAndReturn = (changeCatcher: (parcel: Parcel) => void): [Parcel, ChangeRequest] => {
+    _changeAndReturn = (changeCatcher: (parcel: Parcel) => void): [Parcel, ?ChangeRequest] => {
         let result;
         let {_onHandleChange} = this;
 
@@ -202,7 +201,7 @@ export default class Parcel {
         changeCatcher(this);
         this._onHandleChange = _onHandleChange;
         if(!result) {
-            throw ChangeAndReturnNotCalledError();
+            return [this, undefined];
         }
         return result;
     };

--- a/packages/dataparcels/src/parcel/Parcel.js
+++ b/packages/dataparcels/src/parcel/Parcel.js
@@ -41,7 +41,7 @@ import overload from 'unmutable/lib/util/overload';
 const DEFAULT_CONFIG_INTERNAL = () => ({
     child: undefined,
     dispatchId: '',
-    lastOriginId: '',
+    frameMeta: {},
     meta: {},
     id: new ParcelId(),
     parent: {
@@ -67,7 +67,7 @@ export default class Parcel {
         let {
             child,
             dispatchId,
-            lastOriginId,
+            frameMeta,
             meta,
             id,
             parent,
@@ -75,7 +75,7 @@ export default class Parcel {
             updateChangeRequestOnDispatch
         } = _configInternal || DEFAULT_CONFIG_INTERNAL();
 
-        this._lastOriginId = lastOriginId;
+        this._frameMeta = frameMeta;
         this._onHandleChange = handleChange;
         this._updateChangeRequestOnDispatch = updateChangeRequestOnDispatch;
 
@@ -124,15 +124,15 @@ export default class Parcel {
     //
 
     // from constructor
-    _childParcelCache: { [key: string]: Parcel } = {};
+    _childParcelCache: {[key: string]: Parcel} = {};
     _dispatchId: string;
     _id: ParcelId;
     _isChild: boolean;
     _isElement: boolean;
     _isIndexed: boolean;
     _isParent: boolean;
-    _lastOriginId: string;
-    _methods: { [key: string]: * };
+    _frameMeta: {[key: string]: any};
+    _methods: {[key: string]: any};
     _onHandleChange: ?Function;
     _parcelData: ParcelData;
     _parent: ParcelParent;
@@ -148,7 +148,7 @@ export default class Parcel {
             dispatchId = this._id.id(),
             handleChange,
             id = this._id,
-            lastOriginId = this._lastOriginId,
+            frameMeta = this._frameMeta,
             parcelData = this._parcelData,
             parent = this._parent,
             registry = this._registry,
@@ -169,7 +169,7 @@ export default class Parcel {
             {
                 child,
                 dispatchId,
-                lastOriginId,
+                frameMeta,
                 meta,
                 id,
                 parent,
@@ -190,15 +190,12 @@ export default class Parcel {
 
     _changeAndReturn = (changeCatcher: (parcel: Parcel) => void): [Parcel, ChangeRequest] => {
         let result;
-        let {_onHandleChange, _lastOriginId} = this;
+        let {_onHandleChange} = this;
 
         // swap out the parcels real _onHandleChange with a spy
         this._onHandleChange = (parcel, changeRequest) => {
-            // _changeAndReturn should not alter _lastOriginId
-            // as it's never triggered by a user action
-            // so revert to the current parcel's _lastOriginId
             parcel._onHandleChange = _onHandleChange;
-            parcel._lastOriginId = _lastOriginId;
+            parcel._frameMeta = this._frameMeta;
             result = [parcel, changeRequest];
         };
 

--- a/packages/dataparcels/src/parcel/__test__/Parcel-test.js
+++ b/packages/dataparcels/src/parcel/__test__/Parcel-test.js
@@ -36,7 +36,6 @@ test('Parcel._changeAndReturn() should call action and return Parcel', () => {
         },
         handleChange
     });
-    parcel._lastOriginId = "foo";
 
     let [newParcel] = parcel._changeAndReturn((parcel) => {
         parcel.get('abc').onChange(789);
@@ -59,9 +58,8 @@ test('Parcel._changeAndReturn() should call action and return Parcel', () => {
     newParcel.get('abc').onChange(100);
     expect(handleChange).toHaveBeenCalledTimes(2);
 
-    // _changeAndReturn should not affect parcel._lastOriginId as it is an internal function
-    // that never corresponds to actions triggered by user input
-    expect(newParcel._lastOriginId).toBe("foo");
+    // _frameMeta should be passed through
+    expect(parcel._frameMeta).toBe(newParcel._frameMeta);
 });
 
 test('Parcel._changeAndReturn() should throw error if no changes are made', () => {
@@ -265,5 +263,30 @@ test('Correct methods are created for array element values', () => {
     expect(() => new Parcel(data).get(0).pop()).toThrowError(`.pop() is not a function`);
     expect(() => new Parcel(data).get(0).delete()).not.toThrow();
     expect(() => new Parcel(data).get(0).swapNext()).not.toThrow();
+});
+
+test('Frame meta should be passed down to child parcels', () => {
+    let parcel = new Parcel({
+        value: [[123]]
+    });
+
+    parcel._frameMeta.foo = 123;
+
+    expect(parcel.get(0)._frameMeta.foo).toBe(123);
+    expect(parcel.get(0).get(0)._frameMeta.foo).toBe(123);
+});
+
+test('Frame meta should not persist after change', () => {
+    let handleChange = jest.fn();
+
+    let parcel = new Parcel({
+        value: 123,
+        handleChange
+    });
+
+    parcel._frameMeta.foo = "bar";
+    parcel.set(456);
+
+    expect(handleChange.mock.calls[0][0]._frameMeta).toEqual({});
 });
 

--- a/packages/dataparcels/src/parcel/__test__/Parcel-test.js
+++ b/packages/dataparcels/src/parcel/__test__/Parcel-test.js
@@ -62,7 +62,7 @@ test('Parcel._changeAndReturn() should call action and return Parcel', () => {
     expect(parcel._frameMeta).toBe(newParcel._frameMeta);
 });
 
-test('Parcel._changeAndReturn() should throw error if no changes are made', () => {
+test('Parcel._changeAndReturn() should return [parcel, undefined] if no changes are made', () => {
     let handleChange = jest.fn();
 
     let parcel = new Parcel({
@@ -73,7 +73,9 @@ test('Parcel._changeAndReturn() should throw error if no changes are made', () =
         handleChange
     });
 
-    expect(() => parcel._changeAndReturn((parcel) => {})).toThrow("_changeAndReturn unchanged");
+    let result = parcel._changeAndReturn(() => {});
+
+    expect(result).toEqual([parcel, undefined]);
 });
 
 test('Parcel types should correctly identify primitive values', () => {

--- a/packages/dataparcels/src/parcel/methods/ParcelChangeMethods.js
+++ b/packages/dataparcels/src/parcel/methods/ParcelChangeMethods.js
@@ -47,7 +47,7 @@ export default (_this: Parcel) => ({
             let parcelWithChangedData = _this._create({
                 handleChange: _onHandleChange,
                 parcelData,
-                lastOriginId: changeRequest.originId
+                frameMeta: {}
             });
 
             _onHandleChange(parcelWithChangedData, changeRequestWithBase);

--- a/packages/dataparcels/src/parcel/methods/ParcelChangeMethods.js
+++ b/packages/dataparcels/src/parcel/methods/ParcelChangeMethods.js
@@ -29,6 +29,12 @@ export default (_this: Parcel) => ({
             changeRequest._originPath = _this.path;
         }
 
+        // clear changeRequest's cache
+        changeRequest = changeRequest._create({
+            prevData: undefined,
+            nextData: undefined
+        });
+
         if(process.env.NODE_ENV !== 'production' && _this._log) {
             console.log(`Parcel: "${_this._logName}" data up:`); // eslint-disable-line
             console.log(changeRequest.toJS()); // eslint-disable-line

--- a/packages/dataparcels/src/types/Types.js
+++ b/packages/dataparcels/src/types/Types.js
@@ -31,7 +31,7 @@ export type ParcelConfigInternal = {
     child: *,
     dispatchId: string,
     id: ParcelId,
-    lastOriginId: string,
+    frameMeta: {[key: string]: any},
     meta: ParcelMeta,
     parent: ParcelParent,
     registry: ParcelRegistry,
@@ -40,7 +40,7 @@ export type ParcelConfigInternal = {
 
 export type ParcelCreateConfigType = {
     dispatchId?: string,
-    lastOriginId?: string,
+    frameMeta?: {[key: string]: any},
     id?: ParcelId,
     handleChange?: Function,
     parcelData?: ParcelData,

--- a/packages/react-dataparcels/src/ParcelBoundaryDeprecated.jsx
+++ b/packages/react-dataparcels/src/ParcelBoundaryDeprecated.jsx
@@ -125,7 +125,7 @@ export default class ParcelBoundary extends React.Component<Props, State> { /* e
             let newData = parcel.data;
 
             if(keepValue) {
-                let changedBySelf = parcel._lastOriginId.startsWith(parcel.id);
+                let changedBySelf = parcel._frameMeta.lastOriginId.startsWith(parcel.id);
                 if(changedBySelf) {
                     newState.lastValueFromSelf = parcel.value;
                 }

--- a/packages/react-dataparcels/src/ParcelHoc.jsx
+++ b/packages/react-dataparcels/src/ParcelHoc.jsx
@@ -138,6 +138,10 @@ export default (config: ParcelHocConfig): Function => {
         }
 
         handleChange = (parcel: Parcel, changeRequest: ChangeRequest) => {
+            parcel._frameMeta = {
+                lastOriginId: changeRequest.originId
+            };
+
             this.setState({parcel});
             if(process.env.NODE_ENV !== 'production' && debugParcel) {
                 console.log(`ParcelHoc: Parcel changed:`); // eslint-disable-line

--- a/packages/react-dataparcels/src/__test__/ParcelBoundaryDeprecated-test.js
+++ b/packages/react-dataparcels/src/__test__/ParcelBoundaryDeprecated-test.js
@@ -467,6 +467,9 @@ test('ParcelBoundary should not update value from props for updates caused by th
     childParcel.onChange(456);
 
     let newParcel = handleChange.mock.calls[0][0];
+    newParcel._frameMeta = {
+        lastOriginId: handleChange.mock.calls[0][1].originId
+    };
 
     // verify that the current value of the parcel has been updated
     expect(newParcel.value).toBe(457);
@@ -483,6 +486,9 @@ test('ParcelBoundary should not update value from props for updates caused by th
     // make a change externally and ensure that the value in the boundary does update
     newParcel.set(789);
     let newParcel2 = handleChange.mock.calls[1][0];
+    newParcel2._frameMeta = {
+        lastOriginId: handleChange.mock.calls[1][1].originId
+    };
     wrapper.setProps({
         parcel: withModify(newParcel2)
     });
@@ -510,6 +516,9 @@ test('ParcelBoundary should update meta from props for updates caused by themsel
     childParcel.onChange(456);
 
     let newParcel = handleChange.mock.calls[0][0];
+    newParcel._frameMeta = {
+        lastOriginId: handleChange.mock.calls[0][1].originId
+    };
 
     // make a change that keepValue will prevent from altering its value
     wrapper.setProps({
@@ -522,6 +531,9 @@ test('ParcelBoundary should update meta from props for updates caused by themsel
         abc: 789
     });
     let newParcel2 = handleChange.mock.calls[1][0];
+    newParcel2._frameMeta = {
+        lastOriginId: handleChange.mock.calls[1][1].originId
+    };
     wrapper.setProps({
         parcel: withModify(newParcel2)
     });

--- a/packages/react-dataparcels/src/__test__/useParcelBuffer-test.js
+++ b/packages/react-dataparcels/src/__test__/useParcelBuffer-test.js
@@ -440,6 +440,9 @@ describe('useParcelBuffer should use config.keepValue', () => {
         });
 
         let newParcel = handleChange.mock.calls[0][0];
+        newParcel._frameMeta = {
+            lastOriginId: handleChange.mock.calls[0][1].originId
+        };
 
         expect(newParcel.value).toEqual({
             abc: NaN

--- a/packages/react-dataparcels/src/__test__/useParcelBuffer-test.js
+++ b/packages/react-dataparcels/src/__test__/useParcelBuffer-test.js
@@ -72,13 +72,17 @@ describe('useParcelBuffer should use config.parcel', () => {
         expect(result.current[0]).toBe(firstResult);
     });
 
-    it('should pass new inner parcel if outer parcel is different', () => {
+    it('should pass new inner parcel and clear buffer contents if outer parcel is different', () => {
 
         let parcel = new Parcel({
             value: 123
         });
 
         let {result, rerender} = renderHookWithProps({parcel}, ({parcel}) => useParcelBuffer({parcel}));
+
+        act(() => {
+            result.current[0].set(124);
+        });
 
         act(() => {
             rerender({
@@ -88,7 +92,10 @@ describe('useParcelBuffer should use config.parcel', () => {
             });
         });
 
+        // inner parcel should have outer parcels value
         expect(result.current[0].value).toEqual(456);
+        // buffer should be cleared
+        expect(result.current[1].actions.length).toBe(0);
     });
 
 });

--- a/packages/react-dataparcels/src/__test__/useParcelBufferInternalKeepValue-test.js
+++ b/packages/react-dataparcels/src/__test__/useParcelBufferInternalKeepValue-test.js
@@ -16,7 +16,7 @@ describe('useParcelBufferInternalKeepValue should work', () => {
     it('should return false when keepValue is false and change comes from self', () => {
 
         let parcel = new Parcel({value}).get('abc');
-        parcel._lastOriginId = "^.abc";
+        parcel._frameMeta.lastOriginId = "^.abc";
 
         let {result} = renderHook(() => useParcelBufferInternalKeepValue({
             keepValue: false,
@@ -29,7 +29,7 @@ describe('useParcelBufferInternalKeepValue should work', () => {
     it('should return true when keepValue is true and change comes from self', () => {
 
         let parcel = new Parcel({value}).get('abc');
-        parcel._lastOriginId = "^.abc";
+        parcel._frameMeta.lastOriginId = "^.abc";
 
         let {result} = renderHook(() => useParcelBufferInternalKeepValue({
             keepValue: true,
@@ -42,7 +42,7 @@ describe('useParcelBufferInternalKeepValue should work', () => {
     it('should return true when keepValue is true and change comes from within self', () => {
 
         let parcel = new Parcel({value}).get('abc');
-        parcel._lastOriginId = "^.abc.a";
+        parcel._frameMeta.lastOriginId = "^.abc.a";
 
         let {result} = renderHook(() => useParcelBufferInternalKeepValue({
             keepValue: true,
@@ -55,7 +55,7 @@ describe('useParcelBufferInternalKeepValue should work', () => {
     it('should return false when keepValue is true and change comes from elsewhere', () => {
 
         let parcel = new Parcel({value}).get('abc');
-        parcel._lastOriginId = "^";
+        parcel._frameMeta.lastOriginId = "^";
 
         let {result} = renderHook(() => useParcelBufferInternalKeepValue({
             keepValue: true,
@@ -68,7 +68,7 @@ describe('useParcelBufferInternalKeepValue should work', () => {
     it('should return true when a change from elsewhere contains the same value as the last change that came from self', () => {
 
         let parcel = new Parcel({value}).get('abc');
-        parcel._lastOriginId = "^.abc";
+        parcel._frameMeta.lastOriginId = "^.abc";
 
         let {result, rerender} = renderHookWithProps({parcel}, ({parcel}) => useParcelBufferInternalKeepValue({
             keepValue: true,
@@ -79,7 +79,7 @@ describe('useParcelBufferInternalKeepValue should work', () => {
 
         act(() => {
             // pretend that a another identical change came from 'def'
-            parcel._lastOriginId = "^.def";
+            parcel._frameMeta.lastOriginId = "^.def";
 
             rerender({
                 parcel
@@ -91,7 +91,7 @@ describe('useParcelBufferInternalKeepValue should work', () => {
         act(() => {
             // pretend that a another change came from 'def', but this time with a changed value
             parcel = parcel._changeAndReturn(parcel => parcel.set(124))[0];
-            parcel._lastOriginId = "^.def";
+            parcel._frameMeta.lastOriginId = "^.def";
 
             rerender({
                 parcel
@@ -104,7 +104,7 @@ describe('useParcelBufferInternalKeepValue should work', () => {
     it('should clear any memory of received values if keepValue becomes false', () => {
 
         let parcel = new Parcel({value}).get('abc');
-        parcel._lastOriginId = "^.abc";
+        parcel._frameMeta.lastOriginId = "^.abc";
 
         let {result, rerender} = renderHookWithProps(
             {
@@ -129,7 +129,7 @@ describe('useParcelBufferInternalKeepValue should work', () => {
         act(() => {
             // pretend that a change came from 'def' with the same value
             // that was recieved when keepValue was last true
-            parcel._lastOriginId = "^.def";
+            parcel._frameMeta.lastOriginId = "^.def";
 
             rerender({
                 parcel,

--- a/packages/react-dataparcels/src/useParcelBuffer.js
+++ b/packages/react-dataparcels/src/useParcelBuffer.js
@@ -172,6 +172,12 @@ export default (params: Params): Return => {
         };
 
         const newOuterParcel = params.parcel;
+        setOuterParcel(newOuterParcel);
+
+        // clear buffer if it exists
+        if(internalBuffer.bufferState) {
+            internalBuffer.reset();
+        }
 
         // boundary split to ensure that inner parcels chain are
         // completely isolated from outer parcels chain
@@ -183,7 +189,6 @@ export default (params: Params): Return => {
             );
 
         setInnerParcel(newInnerParcel);
-        setOuterParcel(newOuterParcel);
     }
 
     let returnedParcel: Parcel = innerParcel || newInnerParcel;

--- a/packages/react-dataparcels/src/useParcelBuffer.js
+++ b/packages/react-dataparcels/src/useParcelBuffer.js
@@ -138,6 +138,12 @@ export default (params: Params): Return => {
         const handleChange = (newParcel: Parcel, changeRequest: ChangeRequest) => {
             const {debounce, buffer = true, keepValue} = params;
 
+            // remember the origin of the last change
+            // useParcelBufferInternalKeepValue needs it
+            newParcel._frameMeta = {
+                lastOriginId: changeRequest.originId
+            };
+
             // remove buffer actions meta from change request
             // and push any remaining change into the buffer
             let actions = changeRequest._actions.filter(removeInternalMeta);

--- a/packages/react-dataparcels/src/useParcelBuffer.js
+++ b/packages/react-dataparcels/src/useParcelBuffer.js
@@ -187,7 +187,6 @@ export default (params: Params): Return => {
             ._changeAndReturn(parcel => {
                 // apply buffered changes to new parcel from props
                 let changeRequest = internalBuffer.bufferState;
-                // TODO: this resetting of the changerequests state should be handled by dispatch...
                 changeRequest && parcel.dispatch(changeRequest);
             })[0]
             .pipe(applyModifiers);

--- a/packages/react-dataparcels/src/useParcelBufferInternalKeepValue.js
+++ b/packages/react-dataparcels/src/useParcelBufferInternalKeepValue.js
@@ -20,8 +20,8 @@ export default ({keepValue, parcel}: Params): boolean => {
         return false;
     }
 
-
-    let changedBySelf = parcel._lastOriginId.startsWith(parcel.id);
+    let {lastOriginId = ''} = parcel._frameMeta;
+    let changedBySelf = lastOriginId.startsWith(parcel.id);
     if(changedBySelf) {
         keepValueReceivedRef.current = parcel.value;
         return true;

--- a/packages/react-dataparcels/src/useParcelState.js
+++ b/packages/react-dataparcels/src/useParcelState.js
@@ -54,6 +54,13 @@ export default (params: Params): Return => {
     const [parcel, setParcel] = useState(() => updateParcelValue(
         new Parcel({
             handleChange: (parcel: Parcel, changeRequest: ChangeRequest) => {
+
+                // remember the origin of the last change
+                // useParcelBufferInternalKeepValue needs it
+                parcel._frameMeta = {
+                    lastOriginId: changeRequest.originId
+                };
+
                 setParcel(applyBeforeChange(parcel));
 
                 if(params.onChange) {


### PR DESCRIPTION
### dataparcels
- Refactor to remove `_lastOriginId`, replace with more generic `frameMeta`
  - frameMetas job is to hold data that should only exist until the next change occurs (the current parcel frame). lastOriginId requires that same data lifespan.
  - lastOriginId was a concept that only react-dataparcels was interested in, and probably shouldnt have been put in plain dataparcels
- Fix issue where change requests's cache wasn't bieng reset by `dispatch()` when it should
- No breaking changes

### react-dataparcels
- refactor to use frameMeta to set and get lastOriginId
- refactor that added ability for `useParcelBuffer` (and therefore `useParcelForm`) to rebase changes when `frameMeta.mergeMode === "rebase"`
  - This will be used by rekey to rebase changerequests onto values that have updated
  - Not part of public API yet
- No breaking changes