### PR TITLE
Quick fixes for v0.23.0 and v0.24.0

### DIFF
--- a/packages/dataparcels-docs/yalc.lock
+++ b/packages/dataparcels-docs/yalc.lock
@@ -7,7 +7,7 @@
       "replaced": "^0.21.0"
     },
     "react-dataparcels-drag": {
-      "signature": "2c04aec0d15b4c1ef76e5f8551a6a79a",
+      "signature": "98f681217ccdf546520c6c0936b3b744",
       "file": true,
       "replaced": "^0.21.0"
     }

--- a/packages/dataparcels-docs/yalc.lock
+++ b/packages/dataparcels-docs/yalc.lock
@@ -2,7 +2,7 @@
   "version": "v1",
   "packages": {
     "react-dataparcels": {
-      "signature": "0c46ebfa110df8fbebc84e52953ce110",
+      "signature": "9bf01c7f1c364ab6414e7c3ae70126ef",
       "file": true,
       "replaced": "^0.21.0"
     },

--- a/packages/react-dataparcels-drag/src/Drag.js
+++ b/packages/react-dataparcels-drag/src/Drag.js
@@ -8,6 +8,20 @@ import React from 'react';
 import {SortableContainer} from 'react-sortable-hoc';
 import {SortableElement} from 'react-sortable-hoc';
 
+const DragElement = SortableElement(({parcel, childRenderer}) => childRenderer(parcel));
+
+const DragContainer = SortableContainer(({parcel, container, childRenderer}) => {
+    let Container = container || 'div';
+    return <Container>
+        {parcel.toArray((elementParcel, index) => <DragElement
+            key={elementParcel.key}
+            index={index}
+            parcel={elementParcel}
+            childRenderer={childRenderer}
+        />)}
+    </Container>;
+});
+
 type Props = {
     children: (parcel: Parcel) => Node,
     parcel: Parcel,
@@ -20,18 +34,10 @@ export default ({children, parcel, onSortEnd, container, ...sortableElementProps
         throw new Error(`react-dataparcels-drag's parcel prop must be of type indexed`);
     }
 
-    let Container = container || 'div';
-    let ConfiguredElement = SortableElement(({parcel}) => children(parcel));
-    let ConfiguredContainer = SortableContainer(({parcel}) => <Container>
-        {parcel.toArray((elementParcel, index) => <ConfiguredElement
-            key={elementParcel.key}
-            index={index}
-            parcel={elementParcel}
-        />)}
-    </Container>);
-
-    return <ConfiguredContainer
+    return <DragContainer
         parcel={parcel}
+        container={container}
+        childRenderer={children}
         onSortEnd={(param) => {
             let {oldIndex, newIndex} = param;
             parcel.move(oldIndex, newIndex);

--- a/packages/react-dataparcels/src/__test__/useParcelBuffer-test.js
+++ b/packages/react-dataparcels/src/__test__/useParcelBuffer-test.js
@@ -329,6 +329,48 @@ describe('useParcelBuffer should use config.debounce', () => {
         expect(handleChange.mock.calls[1][0].value).toEqual(["C"]);
     });
 
+    it('should debounce even when buffer = false', () => {
+        let handleChange = jest.fn();
+
+        let parcel = new Parcel({
+            value: [],
+            handleChange
+        });
+
+        let {result} = renderHook(() => useParcelBuffer({
+            parcel,
+            debounce: 20,
+            buffer: false
+        }));
+
+        act(() => {
+            result.current[0].push("A");
+        });
+
+        act(() => {
+            jest.advanceTimersByTime(10);
+        });
+
+        act(() => {
+            result.current[0].push("B");
+        });
+
+        act(() => {
+            jest.advanceTimersByTime(40);
+        });
+
+        act(() => {
+            result.current[0].push("C");
+        });
+
+        act(() => {
+            jest.advanceTimersByTime(40);
+        });
+
+        expect(handleChange.mock.calls[0][0].value).toEqual(["A", "B"]);
+        expect(handleChange.mock.calls[1][0].value).toEqual(["C"]);
+    });
+
     it('should flush debounced changes if config.debounce is removed', () => {
 
         let handleChange = jest.fn();

--- a/packages/react-dataparcels/src/useParcelBuffer.js
+++ b/packages/react-dataparcels/src/useParcelBuffer.js
@@ -151,7 +151,7 @@ export default (params: Params): Return => {
                 internalBuffer.push(changeRequest._create({actions}));
             }
 
-            if(buffer) {
+            if(buffer || debounce) {
                 // if buffer is to be used, update inner parcel immediately
                 // and request a debounced submit if debounce is set
                 setInnerParcel(newParcel.pipe(applyModifiers));


### PR DESCRIPTION
## react-dataparcels
- fix: `useParcelBuffer` should debounce even when `buffer` param is explicitly set to `false`.
- No breaking changes

## react-dataparcels-drag
- fix: `react-dataparcels-drag` should never have hocked in a render method. Fixes bug where hoc remounts ever render, which throws focus off of inputs as you type.
- No breaking changes