### PR TITLE
Feature/rebasing

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "lerna": "3.10.7",
   "npmClient": "yarn",
-  "version": "0.25.0-alpha.0"
+  "version": "0.25.0-alpha.1"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "lerna": "3.10.7",
   "npmClient": "yarn",
-  "version": "0.24.1"
+  "version": "0.25.0-alpha.0"
 }

--- a/packages/dataparcels-docs/package.json
+++ b/packages/dataparcels-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dataparcels-docs",
   "private": true,
-  "version": "0.24.1",
+  "version": "0.25.0-alpha.0",
   "description": "Dataparcels Documentation",
   "author": "Damien Clarke",
   "license": "MIT",
@@ -12,7 +12,7 @@
     "watch": "gatsby develop"
   },
   "dependencies": {
-    "dataparcels": "^0.24.0",
+    "dataparcels": "^0.25.0-alpha.0",
     "dcme-gatsby": "^0.5.0",
     "dcme-style": "^0.27.4",
     "gatsby": "^2.0.19",

--- a/packages/dataparcels-docs/package.json
+++ b/packages/dataparcels-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dataparcels-docs",
   "private": true,
-  "version": "0.25.0-alpha.0",
+  "version": "0.25.0-alpha.1",
   "description": "Dataparcels Documentation",
   "author": "Damien Clarke",
   "license": "MIT",
@@ -12,7 +12,7 @@
     "watch": "gatsby develop"
   },
   "dependencies": {
-    "dataparcels": "^0.25.0-alpha.0",
+    "dataparcels": "^0.25.0-alpha.1",
     "dcme-gatsby": "^0.5.0",
     "dcme-style": "^0.27.4",
     "gatsby": "^2.0.19",

--- a/packages/dataparcels-docs/src/examples/SubmitButtonOnChangeLoad.jsx
+++ b/packages/dataparcels-docs/src/examples/SubmitButtonOnChangeLoad.jsx
@@ -33,7 +33,8 @@ export default function PersonEditor(props) {
     let [personParcel, personParcelControl] = useParcelForm({
         value: initialValue,
         onSubmit: (parcel) => saveMyData(parcel.value),
-        onSubmitUseResult: true
+        onSubmitUseResult: true,
+        rebase: true
     });
 
     let {timeUpdated} = personParcel.value;

--- a/packages/dataparcels-docs/src/examples/SubmitButtonOnChangeLoadSource.txt
+++ b/packages/dataparcels-docs/src/examples/SubmitButtonOnChangeLoadSource.txt
@@ -7,7 +7,8 @@ export default function PersonEditor(props) {
     let [personParcel, personParcelControl] = useParcelForm({
         value: props.valueLoadedFromServer,
         onSubmit: (parcel) => saveMyData(parcel.value),
-        onSubmitUseResult: true
+        onSubmitUseResult: true,
+        rebase: true
     });
 
     let {timeUpdated} = personParcel.value;

--- a/packages/dataparcels-docs/src/examples/SubmitButtonOnChangeReduxSource.txt
+++ b/packages/dataparcels-docs/src/examples/SubmitButtonOnChangeReduxSource.txt
@@ -7,7 +7,8 @@ export default function PersonEditor(props) {
     let [personParcel, personParcelControl] = useParcelForm({
         value: props.personData,
         updateValue: true,
-        onSubmit: (parcel) => props.dispatchMySaveAction(parcel.value)
+        onSubmit: (parcel) => props.dispatchMySaveAction(parcel.value),
+        rebase: true
     });
 
     // ^ dispatchMySaveAction should return a promise if it is

--- a/packages/dataparcels-docs/src/pages/api/ParcelBoundary.mdx
+++ b/packages/dataparcels-docs/src/pages/api/ParcelBoundary.mdx
@@ -77,6 +77,24 @@ The return value of `childRenderer` will be rendered.
 
 ## <DocsSectionHeading>Props</DocsSectionHeading>
 
+### parcel
+
+```flow
+parcel: Parcel
+```
+
+The parcel to put into the boundary.
+
+#### Behaviour notes
+
+Whenever a ParcelBoundary receives a new Parcel via props, ParcelBoundary's default behaviour is to:
+- update to contain the new Parcel’s data
+- forget about all its buffered changes
+
+This is safe default behaviour because changes in the buffer may not be compatible with the new Parcel's data shape. However it may be user unfriendly in some cases, depending on when and how often the parcel updates from props.
+
+If you would like to keep the changes in the buffer, and you know that buffered changes will always be compatible with any new Parcel's data shape, consider using [useParcelForm.rebase](/api/useParcelForm#rebase) or [useParcelState.rebase](/api/useParcelState#rebase).
+
 ### pure
 
 ```flow

--- a/packages/dataparcels-docs/src/pages/api/useParcelBuffer.mdx
+++ b/packages/dataparcels-docs/src/pages/api/useParcelBuffer.mdx
@@ -49,6 +49,16 @@ parcel: Parcel
 
 The useParcelBuffer hook must be passed a `parcel`, the Parcel which the buffer will apply to.
 
+#### Behaviour notes
+
+Whenever a useParcelBuffer hook receives a new Parcel via props, its default behaviour is to:
+- update to contain the new Parcel’s data
+- forget about all its buffered changes
+
+This is safe default behaviour because changes in the buffer may not be compatible with the new Parcel's data shape. However it may be user unfriendly in some cases, depending on when and how often the parcel updates.
+
+If you would like to keep the changes in the buffer, and you know that buffered changes will always be compatible with any new Parcel's data shape, consider using [useParcelForm.rebase](/api/useParcelForm#rebase) or [useParcelState.rebase](/api/useParcelState#rebase).
+
 ### buffer
 
 ```flow

--- a/packages/dataparcels-docs/src/pages/api/useParcelForm.jsx
+++ b/packages/dataparcels-docs/src/pages/api/useParcelForm.jsx
@@ -12,6 +12,7 @@ export default () => <Layout>
             '# Params',
             'value',
             'updateValue',
+            'rebase',
             'onSubmit',
             'onSubmitUseResult',
             'buffer',

--- a/packages/dataparcels-docs/src/pages/api/useParcelForm.mdx
+++ b/packages/dataparcels-docs/src/pages/api/useParcelForm.mdx
@@ -24,6 +24,7 @@ let [parcel] = useParcelForm({
     value: any,
     // optional
     updateValue?: boolean,
+    rebase?: boolean,
     onSubmit?: Function,
     onSubmitUseResult?: boolean,
     buffer?: boolean,
@@ -88,6 +89,8 @@ updateValue?: boolean = false // optional
 
 When `updateValue` is set to true during an update, the useParcelForm hook will check to see if `value` has changed, and will update its Parcel's value if so. This will completely replace any changes that may have happened to the Parcel since the last time `value` was put into the Parcel.
 
+Note that it will also cause any downstream [useParcelBuffer](/api/useParcelBuffer#parcel) hooks and [ParcelBoundaries](/api/ParcelBoundary#parcel) to forget all their buffered changes, unless [rebase](#rebase) is used.
+
 Value changes are detected using `Object.is()`, comparing the new `value` with the previous one.
 
 ```js
@@ -108,6 +111,22 @@ parcel.set(200);
 // if component updates and receivedValue is now 300
 // then parcel.value is now 300
 ```
+
+### rebase
+
+```flow
+rebase?: boolean = false // optional
+```
+
+As described above, updates caused by `updateValue` (or `onSubmitUseResult`) will cause any downstream [useParcelBuffer](/api/useParcelBuffer#parcel) hooks and [ParcelBoundaries](/api/ParcelBoundary#parcel) to forget all their buffered changes. This is safe default behaviour because changes in the downstream buffers may not be compatible with the new Parcel's data shape. However it may be user unfriendly in some cases, depending on when and how often the parcel updates.
+
+Setting `rebase` to true will prevent downstream buffers from being cleared. This can allow the user to continue editing data seamlessly while new changes are received.
+
+#### Please note
+
+Only use this if the shape of your data does not change, so that downstream buffered changes are compatible with the new Parcel's data shape.
+
+This restriction will be lifted in future with the introduction of a feature known as *rekey*.
 
 ### onSubmit
 
@@ -158,6 +177,8 @@ let [parcel] = useParcelForm({
     onSubmitUseResult: true
 });
 ```
+
+Note that it will also cause any downstream [useParcelBuffer](/api/useParcelBuffer#parcel) hooks and [ParcelBoundaries](/api/ParcelBoundary#parcel) to forget all their buffered changes, unless [rebase](#rebase) is used.
 
 ### buffer
 

--- a/packages/dataparcels-docs/src/pages/api/useParcelState.jsx
+++ b/packages/dataparcels-docs/src/pages/api/useParcelState.jsx
@@ -12,6 +12,7 @@ export default () => <Layout>
             '# Params',
             'value',
             'updateValue',
+            'rebase',
             'onChange',
             'debounce',
             'beforeChange',

--- a/packages/dataparcels-docs/src/pages/api/useParcelState.mdx
+++ b/packages/dataparcels-docs/src/pages/api/useParcelState.mdx
@@ -23,6 +23,7 @@ let [parcel] = useParcelState({
     value: any,
     // optional
     updateValue?: boolean,
+    rebase?: boolean,
     onChange?: Function,
     debounce?: number,
     beforeChange?: Function|Function[]
@@ -74,6 +75,8 @@ updateValue?: boolean = false // optional
 
 When `updateValue` is set to true during an update, the useParcelState hook will check to see if `value` has changed, and will update its Parcel's value if so. This will completely replace any changes that may have happened to the Parcel since the last time `value` was put into the Parcel.
 
+Note that it will also cause any downstream [useParcelBuffer](/api/useParcelBuffer#parcel) hooks and [ParcelBoundaries](/api/ParcelBoundary#parcel) to forget all their buffered changes, unless [rebase](#rebase) is used.
+
 Value changes are detected using `Object.is()`, comparing the new `value` with the previous one.
 
 ```js
@@ -94,6 +97,22 @@ parcel.set(200);
 // if component updates and receivedValue is now 300
 // then parcel.value is now 300
 ```
+
+### rebase
+
+```flow
+rebase?: boolean = false // optional
+```
+
+As described above, updates caused by `updateValue` will cause any downstream [useParcelBuffer](/api/useParcelBuffer#parcel) hooks and [ParcelBoundaries](/api/ParcelBoundary#parcel) to forget all their buffered changes. This is safe default behaviour because changes in the downstream buffers may not be compatible with the new Parcel's data shape. However it may be user unfriendly in some cases, depending on when and how often the parcel updates.
+
+Setting `rebase` to true will prevent downstream buffers from being cleared.
+
+#### Please note
+
+Only use this if the shape of your data does not change, so that downstream buffered changes are compatible with the new Parcel's data shape.
+
+This restriction will be lifted in future with the introduction of a feature known as *rekey*.
 
 ### onChange
 

--- a/packages/dataparcels-docs/src/pages/data-synchronisation.mdx
+++ b/packages/dataparcels-docs/src/pages/data-synchronisation.mdx
@@ -41,12 +41,16 @@ Both these examples show forms that make fake requests to a fake server. The fak
 
 If you're using something like [Redux](https://redux.js.org/), you'll likely be receiving your data via props. That data from Redux should already update as a result of save operations. Use the [updateValue](/api/useParcelForm#updateValue) parameter on useParcelForm to allow the form hook to update based on changes to your source data. Also make sure that the function that does the saving returns a promise, so useParcelForm can know if the request succeeded or not.
 
+The [rebase](/api/useParcelForm#rebase) option is also used here. It allows changes from the source data to slide in underneath any unsaved changes that the user might make after they pressed submit.
+
 <SubmitButtonOnChangeLoad />
 <Code language="jsx">{SubmitButtonOnChangeReduxSource}</Code>
 
 ### Updating form data via a promise
 
 You may not have centralised state management like Redux in your app. In this case you can get useParcelForm to update based off the return value of the promise returned by the save function. To use this approach, set the [onSubmitUseResult](/api/useParcelForm#onSubmitUseResult) parameter to true.
+
+The [rebase](/api/useParcelForm#rebase) option is also used here. It allows the return value of the promise to slide in underneath any unsaved changes that the user might make after they pressed submit.
 
 <SubmitButtonOnChangeLoad />
 <Code language="jsx">{SubmitButtonOnChangeLoadSource}</Code>

--- a/packages/dataparcels-docs/yalc.lock
+++ b/packages/dataparcels-docs/yalc.lock
@@ -2,12 +2,12 @@
   "version": "v1",
   "packages": {
     "react-dataparcels": {
-      "signature": "1f46d00dfd6d1d832b4e7b882bd89b11",
+      "signature": "1162a63c6efe382d452ce87c33524b57",
       "file": true,
       "replaced": "^0.21.0"
     },
     "react-dataparcels-drag": {
-      "signature": "f15e01a0156ea8e313e086b8bc5eb85d",
+      "signature": "ce6ab1a7ba7c29d55c80a3df917c767b",
       "file": true,
       "replaced": "^0.21.0"
     }

--- a/packages/dataparcels-docs/yalc.lock
+++ b/packages/dataparcels-docs/yalc.lock
@@ -2,7 +2,7 @@
   "version": "v1",
   "packages": {
     "react-dataparcels": {
-      "signature": "a35a538ea5cc62c2773cb5a185a9882e",
+      "signature": "9b6fa0533128c357c854bb505205236f",
       "file": true,
       "replaced": "^0.21.0"
     },

--- a/packages/dataparcels-docs/yalc.lock
+++ b/packages/dataparcels-docs/yalc.lock
@@ -2,7 +2,7 @@
   "version": "v1",
   "packages": {
     "react-dataparcels": {
-      "signature": "157becdec276f22c4c211438f1a7cb53",
+      "signature": "1f46d00dfd6d1d832b4e7b882bd89b11",
       "file": true,
       "replaced": "^0.21.0"
     },

--- a/packages/dataparcels-docs/yalc.lock
+++ b/packages/dataparcels-docs/yalc.lock
@@ -2,7 +2,7 @@
   "version": "v1",
   "packages": {
     "react-dataparcels": {
-      "signature": "9b6fa0533128c357c854bb505205236f",
+      "signature": "157becdec276f22c4c211438f1a7cb53",
       "file": true,
       "replaced": "^0.21.0"
     },

--- a/packages/dataparcels-docs/yarn.lock
+++ b/packages/dataparcels-docs/yarn.lock
@@ -3597,10 +3597,10 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
-dataparcels@^0.24.0:
-  version "0.24.0"
-  resolved "https://registry.yarnpkg.com/dataparcels/-/dataparcels-0.24.0.tgz#d38e47df7724eac19aba5f26c11a2f10c2042237"
-  integrity sha512-QenwteqkSfSyLHTJfDWa6gQIOXF0jWssK/sNKuD2Iyu8LMq+/Fj35paj6kv9co4bLrHL6uLcd02PnOzs2bOCDw==
+dataparcels@^0.25.0-alpha.1:
+  version "0.25.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/dataparcels/-/dataparcels-0.25.0-alpha.1.tgz#31ec7ac810ea587dd3a334a60465efc3adc77638"
+  integrity sha512-FJidseLUd3J0vS0DzNG0m6qbkJolO48XlexoKmtzHppU90Da1kcDV9ViJ7auM6T/8W+tntqZAdRbcpveHjsNQQ==
   dependencies:
     "@babel/runtime" "^7.1.5"
     unmutable "^0.41.1"
@@ -9688,16 +9688,16 @@ react-cool-storage@^0.1.1:
     unmutable "^0.39.0"
 
 "react-dataparcels-drag@file:.yalc/react-dataparcels-drag":
-  version "0.24.0-2c04aec0"
+  version "0.25.0-alpha.1-ce6ab1a7"
   dependencies:
     "@babel/runtime" "^7.1.5"
     react-sortable-hoc "1.4.0"
 
 "react-dataparcels@file:.yalc/react-dataparcels":
-  version "0.24.0-0c46ebfa"
+  version "0.25.0-alpha.1-1162a63c"
   dependencies:
     "@babel/runtime" "^7.1.5"
-    dataparcels "^0.24.0"
+    dataparcels "^0.25.0-alpha.1"
     is-promise "^2.1.0"
     unmutable "^0.41.1"
     use-debounce "^1.1.3"

--- a/packages/dataparcels/package.json
+++ b/packages/dataparcels/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dataparcels",
-  "version": "0.24.0",
+  "version": "0.25.0-alpha.0",
   "description": "A library for editing data structures that works really well with React.",
   "main": "lib/index.js",
   "license": "MIT",

--- a/packages/dataparcels/package.json
+++ b/packages/dataparcels/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dataparcels",
-  "version": "0.25.0-alpha.0",
+  "version": "0.25.0-alpha.1",
   "description": "A library for editing data structures that works really well with React.",
   "main": "lib/index.js",
   "license": "MIT",

--- a/packages/dataparcels/src/change/ChangeRequest.js
+++ b/packages/dataparcels/src/change/ChangeRequest.js
@@ -26,6 +26,7 @@ export default class ChangeRequest {
     _originId: ?string = null;
     _originPath: ?string[] = null;
     _revertCallback: ?Function;
+    _nextFrameMeta: {[key: string]: any} = {};
 
     constructor(action: Action|Action[] = []) {
         this._actions = this._actions.concat(action);
@@ -40,6 +41,7 @@ export default class ChangeRequest {
             originId: this._originId,
             originPath: this._originPath,
             revertCallback: this._revertCallback,
+            nextFrameMeta: this._nextFrameMeta,
             ...changeRequestData
         };
 
@@ -50,6 +52,7 @@ export default class ChangeRequest {
         changeRequest._originId = changeRequestData.originId;
         changeRequest._originPath = changeRequestData.originPath;
         changeRequest._revertCallback = changeRequestData.revertCallback;
+        changeRequest._nextFrameMeta = changeRequestData.nextFrameMeta;
         return changeRequest;
     };
 
@@ -123,8 +126,14 @@ export default class ChangeRequest {
             );
         }, this._actions);
 
+        let nextFrameMeta = {
+            ...this._nextFrameMeta,
+            ...other._nextFrameMeta
+        };
+
         return this._create({
             actions,
+            nextFrameMeta,
             nextData: undefined,
             prevData: undefined
         });

--- a/packages/dataparcels/src/change/__test__/ChangeRequest-test.js
+++ b/packages/dataparcels/src/change/__test__/ChangeRequest-test.js
@@ -42,6 +42,34 @@ test('ChangeRequest merge() should merge other change requests actions', () => {
     expect([...actionsA, ...actionsB]).toEqual(merged.actions);
 });
 
+test('ChangeRequest merge() should merge other change requests nextFrameMetas', () => {
+    let actionsA = [
+        new Action({type: "???", keyPath: ['a']}),
+        new Action({type: "!!!", keyPath: ['a']})
+    ];
+
+    let actionsB = [
+        new Action({type: "aaa", keyPath: ['b']}),
+        new Action({type: "bbb", keyPath: ['b']})
+    ];
+
+    let a = new ChangeRequest(actionsA)._create({
+        nextFrameMeta: {foo: 100, bar: 200}
+    });
+
+    let b = new ChangeRequest(actionsB)._create({
+        nextFrameMeta: {bar: 300, baz: 400}
+    });
+
+    let merged = a.merge(b);
+
+    expect(merged._nextFrameMeta).toEqual({
+        foo: 100,
+        bar: 300,
+        baz: 400
+    });
+});
+
 test('ChangeRequest merge() should dedupe subsequent "set" actions with same keyPath', () => {
     let existingChangeRequest = new ChangeRequest([
         new Action({type: "set", keyPath: ['a'], payload: {value: 1}})

--- a/packages/dataparcels/src/parcel/methods/ParcelChangeMethods.js
+++ b/packages/dataparcels/src/parcel/methods/ParcelChangeMethods.js
@@ -53,7 +53,7 @@ export default (_this: Parcel) => ({
             let parcelWithChangedData = _this._create({
                 handleChange: _onHandleChange,
                 parcelData,
-                frameMeta: {}
+                frameMeta: changeRequest._nextFrameMeta
             });
 
             _onHandleChange(parcelWithChangedData, changeRequestWithBase);

--- a/packages/react-dataparcels-drag/package.json
+++ b/packages/react-dataparcels-drag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dataparcels-drag",
-  "version": "0.25.0-alpha.0",
+  "version": "0.25.0-alpha.1",
   "description": "A plugin for react-dataparcels that adds drag and drop re-ordering of elements.",
   "main": "lib/index.js",
   "license": "MIT",
@@ -37,7 +37,7 @@
     "@babel/core": "^7.1.2",
     "babel-preset-blueflag": "^1.0.0",
     "blueflag-test": "^0.22.0",
-    "dataparcels": "^0.25.0-alpha.0",
+    "dataparcels": "^0.25.0-alpha.1",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "size-limit": "^0.21.1"

--- a/packages/react-dataparcels-drag/package.json
+++ b/packages/react-dataparcels-drag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dataparcels-drag",
-  "version": "0.24.1",
+  "version": "0.25.0-alpha.0",
   "description": "A plugin for react-dataparcels that adds drag and drop re-ordering of elements.",
   "main": "lib/index.js",
   "license": "MIT",
@@ -37,7 +37,7 @@
     "@babel/core": "^7.1.2",
     "babel-preset-blueflag": "^1.0.0",
     "blueflag-test": "^0.22.0",
-    "dataparcels": "^0.24.0",
+    "dataparcels": "^0.25.0-alpha.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "size-limit": "^0.21.1"

--- a/packages/react-dataparcels/.size-limit
+++ b/packages/react-dataparcels/.size-limit
@@ -56,7 +56,7 @@
         path: "useParcelForm.js"
     },
     {
-        limit: "14 KB",
+        limit: "15 KB",
         path: "useParcelSideEffect.js"
     },
     {

--- a/packages/react-dataparcels/package.json
+++ b/packages/react-dataparcels/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dataparcels",
-  "version": "0.24.1",
+  "version": "0.25.0-alpha.0",
   "description": "A library for editing data structures that works really well with React.",
   "main": "lib/index.js",
   "license": "MIT",
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.5",
-    "dataparcels": "^0.24.0",
+    "dataparcels": "^0.25.0-alpha.0",
     "is-promise": "^2.1.0",
     "unmutable": "^0.41.1",
     "use-debounce": "^1.1.3"

--- a/packages/react-dataparcels/package.json
+++ b/packages/react-dataparcels/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dataparcels",
-  "version": "0.25.0-alpha.0",
+  "version": "0.25.0-alpha.1",
   "description": "A library for editing data structures that works really well with React.",
   "main": "lib/index.js",
   "license": "MIT",
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.5",
-    "dataparcels": "^0.25.0-alpha.0",
+    "dataparcels": "^0.25.0-alpha.1",
     "is-promise": "^2.1.0",
     "unmutable": "^0.41.1",
     "use-debounce": "^1.1.3"

--- a/packages/react-dataparcels/src/ParcelHoc.jsx
+++ b/packages/react-dataparcels/src/ParcelHoc.jsx
@@ -138,9 +138,7 @@ export default (config: ParcelHocConfig): Function => {
         }
 
         handleChange = (parcel: Parcel, changeRequest: ChangeRequest) => {
-            parcel._frameMeta = {
-                lastOriginId: changeRequest.originId
-            };
+            parcel._frameMeta.lastOriginId = changeRequest.originId;
 
             this.setState({parcel});
             if(process.env.NODE_ENV !== 'production' && debugParcel) {

--- a/packages/react-dataparcels/src/__test__/useParcelBuffer-test.js
+++ b/packages/react-dataparcels/src/__test__/useParcelBuffer-test.js
@@ -98,7 +98,7 @@ describe('useParcelBuffer should use config.parcel', () => {
         expect(result.current[1].actions.length).toBe(0);
     });
 
-    it('should keep inner parcel and buffer contents if outer parcel is different and mergeMode is "rebase"', () => {
+    it('should keep inner parcel and buffer contents if outer parcel is different and frameMeta has rebase = true', () => {
 
         let parcel = new Parcel({
             value: {
@@ -127,7 +127,7 @@ describe('useParcelBuffer should use config.parcel', () => {
                 }
             });
 
-            parcel._frameMeta.mergeMode = "rebase";
+            parcel._frameMeta.rebase = true;
 
             rerender({
                 parcel

--- a/packages/react-dataparcels/src/__test__/useParcelForm-test.js
+++ b/packages/react-dataparcels/src/__test__/useParcelForm-test.js
@@ -36,6 +36,15 @@ describe('useParcelForm should pass config to useParcelState', () => {
         expect(getLastCall(useParcelState)[0].updateValue).toBe(true);
     });
 
+    it('should pass rebase to useParcelState', () => {
+        renderHook(() => useParcelForm({
+            value: 123,
+            rebase: true
+        }));
+
+        expect(getLastCall(useParcelState)[0].rebase).toBe(true);
+    });
+
 });
 
 

--- a/packages/react-dataparcels/src/__test__/useParcelState-test.js
+++ b/packages/react-dataparcels/src/__test__/useParcelState-test.js
@@ -251,3 +251,23 @@ describe('useParcelState should use config.debounce', () => {
         expect(onChange.mock.calls[1][0].value).toEqual(["A", "B", "C"]);
     });
 });
+
+describe('useParcelState should use config.rebase', () => {
+
+    it('should set frame meta of rebase = true', () => {
+        let {result} = renderHook(() => useParcelState({
+            value: 123,
+            rebase: true
+        }));
+
+        expect(result.current[0]._frameMeta.rebase).toBe(true);
+    });
+
+    it('should not normally set frame meta of rebase = true', () => {
+        let {result} = renderHook(() => useParcelState({
+            value: 123
+        }));
+
+        expect(!result.current[0]._frameMeta.rebase).toBe(true);
+    });
+});

--- a/packages/react-dataparcels/src/useParcelBuffer.js
+++ b/packages/react-dataparcels/src/useParcelBuffer.js
@@ -175,7 +175,7 @@ export default (params: Params): Return => {
         setOuterParcel(newOuterParcel);
 
         // clear buffer if it exists and if we aren't rebasing
-        if(internalBuffer.bufferState && newOuterParcel._frameMeta.mergeMode !== "rebase") {
+        if(internalBuffer.bufferState && !newOuterParcel._frameMeta.rebase) {
             internalBuffer.reset();
         }
 

--- a/packages/react-dataparcels/src/useParcelBuffer.js
+++ b/packages/react-dataparcels/src/useParcelBuffer.js
@@ -140,9 +140,7 @@ export default (params: Params): Return => {
 
             // remember the origin of the last change
             // useParcelBufferInternalKeepValue needs it
-            newParcel._frameMeta = {
-                lastOriginId: changeRequest.originId
-            };
+            newParcel._frameMeta.lastOriginId = changeRequest.originId;
 
             // remove buffer actions meta from change request
             // and push any remaining change into the buffer

--- a/packages/react-dataparcels/src/useParcelForm.js
+++ b/packages/react-dataparcels/src/useParcelForm.js
@@ -14,6 +14,7 @@ import useParcelBuffer from './useParcelBuffer';
 type Params = {
     value: any,
     updateValue?: boolean,
+    rebase?: boolean,
     onSubmit?: (parcel: Parcel, changeRequest: ChangeRequest) => any|Promise<any>,
     onSubmitUseResult?: boolean,
     buffer?: boolean,
@@ -29,6 +30,7 @@ export default (params: Params): Return => {
     let {
         value,
         updateValue = false,
+        rebase = false,
         onSubmit,
         onSubmitUseResult = false,
         buffer = true,
@@ -49,7 +51,8 @@ export default (params: Params): Return => {
 
     let [outerParcel] = useParcelState({
         value,
-        updateValue
+        updateValue,
+        rebase
     });
 
     let [sideEffectParcel, sideEffectControl] = useParcelSideEffect({

--- a/packages/react-dataparcels/src/useParcelSideEffect.js
+++ b/packages/react-dataparcels/src/useParcelSideEffect.js
@@ -100,6 +100,16 @@ export default (params: Params): Return => {
             changeRequestWithResult._originId = changeRequest._originId;
             changeRequestWithResult._originPath = changeRequest._originPath;
             changeRequest = changeRequestWithResult;
+        } else {
+            // when onSubmitUseResult is false, its necessary to rebase
+            // so changes made after submit but before
+            // processChangeSuccess() are not overwritten when the top
+            // parcel finally updates
+            changeRequest = changeRequest._create({
+                nextFrameMeta: {
+                    rebase: true
+                }
+            });
         }
 
         statusRef.current = 'resolved';

--- a/packages/react-dataparcels/src/useParcelState.js
+++ b/packages/react-dataparcels/src/useParcelState.js
@@ -12,6 +12,7 @@ import ApplyBeforeChange from './util/ApplyBeforeChange';
 type Params = {
     value: any,
     updateValue?: boolean,
+    rebase?: boolean,
     onChange?: (parcel: Parcel, changeRequest: ChangeRequest) => void,
     debounce?: number,
     beforeChange?: ParcelValueUpdater|ParcelValueUpdater[]
@@ -78,6 +79,10 @@ export default (params: Params): Return => {
             setPrevValue(value);
             setParcel(updateParcelValue(parcel));
         }
+    }
+
+    if(params.rebase) {
+        parcel._frameMeta.rebase = true;
     }
 
     return [parcel];

--- a/packages/react-dataparcels/src/useParcelState.js
+++ b/packages/react-dataparcels/src/useParcelState.js
@@ -57,9 +57,7 @@ export default (params: Params): Return => {
 
                 // remember the origin of the last change
                 // useParcelBufferInternalKeepValue needs it
-                parcel._frameMeta = {
-                    lastOriginId: changeRequest.originId
-                };
+                parcel._frameMeta.lastOriginId = changeRequest.originId;
 
                 setParcel(applyBeforeChange(parcel));
 


### PR DESCRIPTION
## dataparcels
- add: make `frameMeta` based off `ChangeRequest.nextFrameMeta`
  - Changes can then describe meta for the resulting parcel update and re-render. This will be used by `react-dataparcels` to set the merge mode when a change is about to take place, as the change is the thing that knows which merge mode that is appropriate

## react-dataparcels
- add: `rebase` option on `useParcelState` and `useParcelForm`
  - this will allow changes from props to slide in underneath changes in useParcelBuffer hooks and ParcelBoundaries, so data can change without losing unsaved changes.
- add: post-sideeffecthook changes now rebase underneath buffered changes
  - almost more of a fix than a feature... this allows changes made after a `submit()` to not get replaced once a promise returned by `onSubmit` resolves. Only affects cases where `onSubmitUseResult` is not used. If `onSubmitUseResult` then replacing the value is the right behaviour.
