### PR TITLE
Feature/parcel state updater

### DIFF
--- a/packages/dataparcels-docs/src/pages/api/ChangeRequest.jsx
+++ b/packages/dataparcels-docs/src/pages/api/ChangeRequest.jsx
@@ -17,6 +17,7 @@ export default () => <Layout>
             'actions',
             '# Methods',
             'hasValueChanged()',
+            'hasDataChanged()',
             'getDataIn()',
             'merge()'
         ]}

--- a/packages/dataparcels-docs/src/pages/api/ChangeRequest.mdx
+++ b/packages/dataparcels-docs/src/pages/api/ChangeRequest.mdx
@@ -78,6 +78,14 @@ hasValueChanged(keyPath: Array<string|number>): boolean
 
 Return a boolean indicating if the value at the given `keyPath` has changed any of its data as a result of this ChangeRequest.
 
+### hasDataChanged()
+
+```flow
+hasDataChanged(keyPath: Array<string|number>): boolean
+```
+
+Return a boolean indicating if the value or meta at the given `keyPath` has changed any of its data as a result of this ChangeRequest.
+
 ### getDataIn()
 
 ```flow

--- a/packages/dataparcels-docs/src/pages/api/useParcelForm.mdx
+++ b/packages/dataparcels-docs/src/pages/api/useParcelForm.mdx
@@ -71,14 +71,31 @@ parcel.set(200);
 // parcel.value is now 200
 ```
 
-If computing `value` is a heavy operation, you can return the value from a function. The function will only be called on initial mount. However, if `updateValue` is set to true then the function will be called on every update.
+If computing `value` is a heavy operation, you can return the value from a function. The function will only be called on initial mount, and is passed the previous value. However, if `updateValue` is set to true then the function will be called on every update.
 
 ```js
+let newValue = 100;
+
 let [parcel] = useParcelForm({
-    value: () => 100
+    value: (prevValue) => newValue
 });
 
 // parcel.value is 100
+```
+
+Value can also accept [parcel updaters](/parcel-updaters). These pass the previous data held in state, and expect the new data to be returned. These can be useful for setting [parcel meta](/parcel-meta).
+
+```js
+import asNode from 'react-dataparcels/asNode';
+
+let [parcel] = useParcelForm({
+    value: asNode(node => node
+        .update(() => newValue)
+        .setMeta({
+            foo: true
+        })
+    )
+});
 ```
 
 #### Returning promises from value

--- a/packages/dataparcels-docs/src/pages/api/useParcelState.mdx
+++ b/packages/dataparcels-docs/src/pages/api/useParcelState.mdx
@@ -58,14 +58,31 @@ parcel.set(200);
 // parcel.value is now 200
 ```
 
-If computing `value` is a heavy operation, you can return the value from a function. The function will only be called on initial mount. However, if `updateValue` is set to true then the function will be called on every update.
+If computing `value` is a heavy operation, you can return the value from a function. The function will only be called on initial mount, and is passed the previous value. However, if `updateValue` is set to true then the function will be called on every update.
 
 ```js
+let newValue = 100;
+
 let [parcel] = useParcelState({
-    value: () => 100
+    value: (prevValue) => newValue
 });
 
 // parcel.value is 100
+```
+
+Value can also accept [parcel updaters](/parcel-updaters). These pass the previous data held in state, and expect the new data to be returned. These can be useful for setting [parcel meta](/parcel-meta).
+
+```js
+import asNode from 'react-dataparcels/asNode';
+
+let [parcel] = useParcelState({
+    value: asNode(node => node
+        .update(() => newValue)
+        .setMeta({
+            foo: true
+        })
+    )
+});
 ```
 
 #### Returning promises from value

--- a/packages/dataparcels/.size-limit.json
+++ b/packages/dataparcels/.size-limit.json
@@ -12,7 +12,7 @@
         "path": "cancel.js"
     },
     {
-        "limit": "7.3 KB",
+        "limit": "7.4 KB",
         "path": "ChangeRequest.js"
     },
     {

--- a/packages/dataparcels/src/change/ChangeRequest.js
+++ b/packages/dataparcels/src/change/ChangeRequest.js
@@ -5,6 +5,8 @@ import type {Index} from '../types/Types';
 import type {ParcelData} from '../types/Types';
 import type Action from './Action';
 
+import shallowEquals from 'unmutable/shallowEquals';
+
 import {ReadOnlyError} from '../errors/Errors';
 import {ChangeRequestNoPrevDataError} from '../errors/Errors';
 import ChangeRequestReducer from '../change/ChangeRequestReducer';
@@ -138,6 +140,12 @@ export default class ChangeRequest {
             next: getIn(this.nextData),
             prev: getIn(this.prevData)
         };
+    };
+
+    hasDataChanged = (keyPath: Array<Key|Index> = []): boolean => {
+        let {next, prev} = this.getDataIn(keyPath);
+        return !Object.is(next.value, prev.value)
+            || !shallowEquals(next.meta || {})(prev.meta || {});
     };
 
     hasValueChanged = (keyPath: Array<Key|Index> = []): boolean => {

--- a/packages/dataparcels/src/change/__test__/ChangeRequest-test.js
+++ b/packages/dataparcels/src/change/__test__/ChangeRequest-test.js
@@ -380,6 +380,119 @@ test('ChangeRequest hasValueChanged should indicate if value changed in array, i
     expect(basedChangeRequest.hasValueChanged()).toBe(true);
 });
 
+test('ChangeRequest hasDataChanged should indicate if value changed at path', () => {
+    var action = new Action({
+        type: "set",
+        keyPath: ["a", "c", "#a"],
+        payload: 100
+    });
+
+    var parcel = new Parcel({
+        value: {
+            a: {
+                c: [0,1],
+                d: 2
+            },
+            b: 3,
+            e: NaN
+        }
+    });
+
+    let basedChangeRequest = new ChangeRequest(action)._create({
+        prevData: parcel.data
+    });
+
+    expect(basedChangeRequest.hasDataChanged(['a', 'c', '#a'])).toBe(true);
+    expect(basedChangeRequest.hasDataChanged(['a', 'c', '#b'])).toBe(false);
+    expect(basedChangeRequest.hasDataChanged(['a', 'c'])).toBe(true);
+    expect(basedChangeRequest.hasDataChanged(['a', 'd'])).toBe(false);
+    expect(basedChangeRequest.hasDataChanged(['a'])).toBe(true);
+    expect(basedChangeRequest.hasDataChanged(['b'])).toBe(false);
+    expect(basedChangeRequest.hasDataChanged(['e'])).toBe(false);
+    expect(basedChangeRequest.hasDataChanged()).toBe(true);
+});
+
+test('ChangeRequest hasDataChanged should indicate if meta changed at path', () => {
+    var action = new Action({
+        type: "setMeta",
+        keyPath: ["a", "c", "#a"],
+        payload: {
+            abc: 123
+        }
+    });
+
+    var parcel = new Parcel({
+        value: {
+            a: {
+                c: [0,1],
+                d: 2
+            },
+            b: 3,
+            e: NaN
+        }
+    });
+
+    let basedChangeRequest = new ChangeRequest(action)._create({
+        prevData: parcel.data
+    });
+
+    expect(basedChangeRequest.hasDataChanged(['a', 'c', '#a'])).toBe(true);
+    expect(basedChangeRequest.hasDataChanged(['a', 'c', '#b'])).toBe(false);
+    expect(basedChangeRequest.hasDataChanged(['a', 'c'])).toBe(true);
+    expect(basedChangeRequest.hasDataChanged(['a', 'd'])).toBe(false);
+    expect(basedChangeRequest.hasDataChanged(['a'])).toBe(true);
+    expect(basedChangeRequest.hasDataChanged(['b'])).toBe(false);
+    expect(basedChangeRequest.hasDataChanged(['e'])).toBe(false);
+    expect(basedChangeRequest.hasDataChanged()).toBe(true);
+});
+
+test('ChangeRequest hasDataChanged should indicate if value changed at path due to deletion', () => {
+    var action = new Action({
+        type: "delete",
+        keyPath: ["a"]
+    });
+
+    var parcel = new Parcel({
+        value: {
+            a: {
+                b: 100
+            },
+            b: 2
+        }
+    });
+
+    let basedChangeRequest = new ChangeRequest(action)._create({
+        prevData: parcel.data
+    });
+
+    expect(basedChangeRequest.hasDataChanged(['a'])).toBe(true);
+    expect(basedChangeRequest.hasDataChanged(['a', 'b'])).toBe(true);
+    expect(basedChangeRequest.hasDataChanged(['b'])).toBe(false);
+});
+
+test('ChangeRequest hasDataChanged should indicate if value changed in array, identifying elements by key', () => {
+    var action = new Action({
+        type: "insertBefore",
+        keyPath: ["#b"],
+        payload: 999
+    });
+
+    var parcel = new Parcel({
+        value: [0,1,2,3]
+    });
+
+    let basedChangeRequest = new ChangeRequest(action)._create({
+        prevData: parcel.data
+    });
+
+    expect(basedChangeRequest.hasDataChanged(['#a'])).toBe(false);
+    expect(basedChangeRequest.hasDataChanged(['#b'])).toBe(false);
+    expect(basedChangeRequest.hasDataChanged(['#c'])).toBe(false);
+    expect(basedChangeRequest.hasDataChanged(['#d'])).toBe(false);
+    expect(basedChangeRequest.hasDataChanged(['#e'])).toBe(true);
+    expect(basedChangeRequest.hasDataChanged()).toBe(true);
+});
+
 test('ChangeRequest should throw errors when attempted to set getters', () => {
     let readOnly = 'This property is read-only';
 

--- a/packages/react-dataparcels/.size-limit.json
+++ b/packages/react-dataparcels/.size-limit.json
@@ -12,7 +12,7 @@
         "path": "cancel.js"
     },
     {
-        "limit": "7.3 KB",
+        "limit": "7.4 KB",
         "path": "ChangeRequest.js"
     },
     {

--- a/packages/react-dataparcels/src/__test__/useParcelState-test.js
+++ b/packages/react-dataparcels/src/__test__/useParcelState-test.js
@@ -172,20 +172,44 @@ describe('useParcelState should use config.updateValue', () => {
         expect(result.current[0].value).toBe(789);
     });
 
-    // it('should allow updater to be passed as value', () => {
-    //     let {result, rerender} = renderHookWithProps({foo: 123}, (props) => useParcelState({
-    //         value: props.foo,
-    //         updateValue: true
-    //     }));
+    it('should allow updater to be passed as value', () => {
 
-    //     expect(result.current[0].value).toBe(123);
+        let updater = jest.fn((prevData, foo) => {
+            return {
+                value: foo,
+                meta: {
+                    foo
+                }
+            };
+        });
 
-    //     act(() => {
-    //         rerender({foo: 456});
-    //     });
+        let {result, rerender} = renderHookWithProps({foo: 123}, (props) => useParcelState({
+            value: asRaw((prevData) => updater(prevData, props.foo)),
+            updateValue: true
+        }));
 
-    //     expect(result.current[0].value).toBe(456);
-    // });
+        expect(result.current[0].value).toBe(123);
+        expect(result.current[0].meta).toEqual({
+            foo: 123
+        });
+
+        expect(updater.mock.calls[0][0].value).toBe(undefined);
+        expect(updater.mock.calls[0][0].meta).toEqual({});
+
+        act(() => {
+            rerender({foo: 456});
+        });
+
+        expect(result.current[0].value).toBe(456);
+        expect(result.current[0].meta).toEqual({
+            foo: 456
+        });
+
+        expect(updater.mock.calls[1][0].value).toBe(123);
+        expect(updater.mock.calls[1][0].meta).toEqual({
+            foo: 123
+        });
+    });
 });
 
 describe('useParcelState should use config.onChange', () => {

--- a/packages/react-dataparcels/src/__test__/useParcelState-test.js
+++ b/packages/react-dataparcels/src/__test__/useParcelState-test.js
@@ -1,6 +1,7 @@
 // @flow
 import {act} from 'react-hooks-testing-library';
 import {renderHook} from 'react-hooks-testing-library';
+import asRaw from 'dataparcels/asRaw';
 import useParcelState from '../useParcelState';
 import asyncChange from '../asyncChange';
 import asyncValue from '../asyncValue';
@@ -36,6 +37,12 @@ describe('useParcelState should use config.value', () => {
     it('should create a Parcel from value thunk', () => {
         let {result} = renderHook(() => useParcelState({value: () => 123}));
         expect(result.current[0].value).toBe(123);
+    });
+
+    it('should create a Parcel from value updater', () => {
+        let {result} = renderHook(() => useParcelState({value: asRaw(() => ({value: 123, meta: {abc: 456}}))}));
+        expect(result.current[0].value).toBe(123);
+        expect(result.current[0].meta).toEqual({abc: 456});
     });
 
     it('should update Parcel', () => {
@@ -164,6 +171,21 @@ describe('useParcelState should use config.updateValue', () => {
 
         expect(result.current[0].value).toBe(789);
     });
+
+    // it('should allow updater to be passed as value', () => {
+    //     let {result, rerender} = renderHookWithProps({foo: 123}, (props) => useParcelState({
+    //         value: props.foo,
+    //         updateValue: true
+    //     }));
+
+    //     expect(result.current[0].value).toBe(123);
+
+    //     act(() => {
+    //         rerender({foo: 456});
+    //     });
+
+    //     expect(result.current[0].value).toBe(456);
+    // });
 });
 
 describe('useParcelState should use config.onChange', () => {


### PR DESCRIPTION
*Addresses #251*

## dataparcels
- Added `ChangeRequest.hasDataChanged(keyPath)`
- No breaking changes

### react-dataparcels
- Added ability for `useParcelState` and `useParcelForm` to accept parcel updaters as their values. This allows previous values to be accessed, and allows meta to be set from props or set based upon previous data.
- No breaking changes