### PR TITLE
Feature/fixes

### DIFF
--- a/packages/dataparcels/.size-limit.json
+++ b/packages/dataparcels/.size-limit.json
@@ -1,6 +1,6 @@
 [
     {
-        "limit": "10.3 KB",
+        "limit": "10.4 KB",
         "path": "lib/index.js"
     },
     {
@@ -12,7 +12,7 @@
         "path": "cancel.js"
     },
     {
-        "limit": "7.4 KB",
+        "limit": "7.5 KB",
         "path": "ChangeRequest.js"
     },
     {

--- a/packages/dataparcels/src/change/ChangeRequestReducer.js
+++ b/packages/dataparcels/src/change/ChangeRequestReducer.js
@@ -5,6 +5,7 @@ import type {ParcelData} from '../types/Types';
 import type {ParcelDataEvaluator} from '../types/Types';
 
 import pipe from 'unmutable/lib/util/pipe';
+import findLastIndex from 'unmutable/lib/findLastIndex';
 import {ReducerInvalidActionError} from '../errors/Errors';
 import {ReducerInvalidStepError} from '../errors/Errors';
 
@@ -81,7 +82,8 @@ const doDeepAction = (action: Action): ParcelDataEvaluator => {
         if(action.keyPath.length === 0) {
             return type === "delete" ? deleteSelfWithMarker : ii => ii;
         }
-        let lastGetIndex = steps.lastIndexOf(step => step.type === 'get');
+
+        let lastGetIndex = findLastIndex(step => step.type === 'get')(steps);
         steps = steps.slice(0, lastGetIndex);
     }
 

--- a/packages/dataparcels/src/change/__test__/ChangeRequestReducer-test.js
+++ b/packages/dataparcels/src/change/__test__/ChangeRequestReducer-test.js
@@ -423,3 +423,37 @@ test('ChangeRequestReducer should throw error if invalid action step type is use
     })
         .toThrowError(`"wrong" is not a valid action step type`);
 });
+
+test('ChangeRequestReducer should process deep actions that are "parent actions"', () => {
+    var data = {
+        value: {
+            abc: 123,
+            def: 456
+        },
+        key: "^",
+        child: undefined
+    };
+
+    let actions = [
+        ActionCreators
+            .deleteSelf()
+            ._addStep({
+                type: 'mu',
+                updater: update('value', value => value)
+            })
+            ._addStep({
+                type: 'md',
+                updater: update('value', value => value)
+            })
+            ._addStep({
+                type: 'get',
+                key: 'abc'
+            })
+    ];
+
+    let expectedValue = {
+        def: 456
+    };
+
+    expect(makeReducer(actions)(data).value).toEqual(expectedValue);
+});

--- a/packages/react-dataparcels/.size-limit.json
+++ b/packages/react-dataparcels/.size-limit.json
@@ -1,6 +1,6 @@
 [
     {
-        "limit": "10.3 KB",
+        "limit": "10.4 KB",
         "path": "lib/index.js"
     },
     {
@@ -12,7 +12,7 @@
         "path": "cancel.js"
     },
     {
-        "limit": "7.4 KB",
+        "limit": "7.5 KB",
         "path": "ChangeRequest.js"
     },
     {

--- a/packages/react-dataparcels/.size-limit.json
+++ b/packages/react-dataparcels/.size-limit.json
@@ -44,7 +44,7 @@
         "path": "asyncValue.js"
     },
     {
-        "limit": "10.9 KB",
+        "limit": "11 KB",
         "path": "asyncChange.js"
     },
     {

--- a/packages/react-dataparcels/src/useParcelForm.js
+++ b/packages/react-dataparcels/src/useParcelForm.js
@@ -55,7 +55,7 @@ export default (params: Params): Return => {
         value,
         updateValue,
         rebase,
-        onChange: asyncChange(onSubmit),
+        onChange: onSubmit && asyncChange(onSubmit),
         onChangeUseResult: onSubmitUseResult
     });
 

--- a/packages/react-dataparcels/src/useParcelState.js
+++ b/packages/react-dataparcels/src/useParcelState.js
@@ -18,7 +18,7 @@ type Params = {
     value: any,
     updateValue?: boolean,
     rebase?: boolean,
-    onChange?: OnChangeFunction|{sideEffectHook: Function},
+    onChange?: ?OnChangeFunction|{sideEffectHook: Function},
     onChangeUseResult?: boolean,
     beforeChange?: ParcelValueUpdater|ParcelValueUpdater[]
 };


### PR DESCRIPTION
- fix: useParcelForm without onSubmit callback would error
  - Flow tests should have caught this but for some reason running flow on CLI does not catch all flow errors, investigate this
- fix: logic to process nested steps was incorrectly refactored