### PR TITLE
API improvements #2

### DIFF
--- a/packages/dataparcels/src/change/__test__/ChangeRequest-test.js
+++ b/packages/dataparcels/src/change/__test__/ChangeRequest-test.js
@@ -187,7 +187,7 @@ test('ChangeRequest should keep originId and originPath', () => {
 
     new Parcel(data)
         .get('abc')
-        .onChange(456);
+        .set(456);
 });
 
 test('ChangeRequest should cache its data after its calculated, so subsequent calls are faster', () => {

--- a/packages/dataparcels/src/parcel/Parcel.js
+++ b/packages/dataparcels/src/parcel/Parcel.js
@@ -87,6 +87,8 @@ export default class Parcel {
     _parent: ParcelParent;
     _registry: ParcelRegistry;
     _updateChangeRequestOnDispatch: Function;
+    _setInput: Function;
+    _setCheckbox: Function;
 
     //
     // public methods
@@ -94,8 +96,8 @@ export default class Parcel {
 
     // Spread methods
     spread: Function;
-    spreadDOM: Function;
-    spreadDOMCheckbox: Function;
+    spreadInput: Function;
+    spreadCheckbox: Function;
 
     // Branch methods
     get: Function;
@@ -112,9 +114,6 @@ export default class Parcel {
     spyChange: Function;
 
     // Change methods
-    onChange: Function;
-    onChangeDOM: Function;
-    onChangeDOMCheckbox: Function;
     set: Function;
     update: Function;
     delete: Function;
@@ -187,6 +186,14 @@ export default class Parcel {
         this._registry = registry;
         this._registry[this._getIdFromRawId(rawId)] = this;
 
+        this._setInput = (event: Object) => {
+            this.set(event.currentTarget.value);
+        };
+
+        this._setCheckbox = (event: Object) => {
+            this.set(event.currentTarget.checked);
+        };
+
         //
         // method prep
         //
@@ -217,17 +224,17 @@ export default class Parcel {
 
         this.spread = (notFoundValue: any): any => ({
             value: this._getValue(notFoundValue),
-            onChange: this.onChange
+            onChange: this.set
         });
 
-        this.spreadDOM = (notFoundValue: any): any => ({
+        this.spreadInput = (notFoundValue: any): any => ({
             value: this._getValue(notFoundValue),
-            onChange: this.onChangeDOM
+            onChange: this._setInput
         });
 
-        this.spreadDOMCheckbox = (notFoundValue: ?boolean): any => ({
+        this.spreadCheckbox = (notFoundValue: ?boolean): any => ({
             checked: !!this._getValue(notFoundValue),
-            onChange: this.onChangeDOMCheckbox
+            onChange: this._setCheckbox
         });
 
         // Branch methods
@@ -318,18 +325,6 @@ export default class Parcel {
         };
 
         // Change methods
-
-        this.onChange = (value: any) => this.set(value);
-
-        // Types(`onChangeDOM()`, `event`, `event`)(event);
-        this.onChangeDOM = (event: Object) => {
-            this.set(event.currentTarget.value);
-        };
-
-        // Types(`onChangeDOMCheckbox()`, `event`, `event`)(event);
-        this.onChangeDOMCheckbox = (event: Object) => {
-            this.set(event.currentTarget.checked);
-        };
 
         this.set = (value: any) => fireAction('set', value);
 

--- a/packages/dataparcels/src/parcel/__test__/ModifyMethods-test.js
+++ b/packages/dataparcels/src/parcel/__test__/ModifyMethods-test.js
@@ -126,7 +126,7 @@ test('Parcel.modifyUp() should allow you to change the payload of a changed parc
         handleChange
     })
         .modifyUp(updater)
-        .onChange(456);
+        .set(456);
 
     expect(handleChange.mock.calls[0][0].value).toBe(457);
 

--- a/packages/dataparcels/src/parcel/__test__/Parcel-test.js
+++ b/packages/dataparcels/src/parcel/__test__/Parcel-test.js
@@ -7,7 +7,7 @@ import {Map, List} from 'immutable';
 test('Parcels should be able to accept no config', () => {
     let parcel = new Parcel();
     expect(undefined).toEqual(parcel.value);
-    parcel.onChange(123);
+    parcel.set(123);
 });
 
 test('Parcels should be able to accept just value in config', () => {
@@ -15,7 +15,7 @@ test('Parcels should be able to accept just value in config', () => {
         value: 123
     });
     expect(123).toEqual(parcel.value);
-    parcel.onChange(456);
+    parcel.set(456);
 });
 
 test('Parcels should be able to accept just handleChange in config', () => {
@@ -26,7 +26,7 @@ test('Parcels should be able to accept just handleChange in config', () => {
     });
 
     expect(parcel.value).toBe(undefined);
-    parcel.onChange(456);
+    parcel.set(456);
 
     expect(handleChange).toHaveBeenCalledTimes(1);
     expect(handleChange.mock.calls[0][0].value).toBe(456);
@@ -45,7 +45,7 @@ test('Parcel._changeAndReturn() should call action and return Parcel', () => {
     });
 
     let [newParcel] = parcel._changeAndReturn((parcel) => {
-        parcel.get('abc').onChange(789);
+        parcel.get('abc').set(789);
     });
 
     // expect correct parcel to be returned
@@ -58,11 +58,11 @@ test('Parcel._changeAndReturn() should call action and return Parcel', () => {
     expect(handleChange).toHaveBeenCalledTimes(0);
 
     // now if parcel's change methods are called, handleChange should be called as usual
-    parcel.get('abc').onChange(100);
+    parcel.get('abc').set(100);
     expect(handleChange).toHaveBeenCalledTimes(1);
 
     // also if new parcel's change methods are called, handleChange should be called as usual
-    newParcel.get('abc').onChange(100);
+    newParcel.get('abc').set(100);
     expect(handleChange).toHaveBeenCalledTimes(2);
 
     // _frameMeta should be passed through

--- a/packages/dataparcels/src/parcel/__test__/ParcelChangeMethods-test.js
+++ b/packages/dataparcels/src/parcel/__test__/ParcelChangeMethods-test.js
@@ -13,7 +13,7 @@ test('Parcel.dispatch() should pass handleChange to newly created parcel', () =>
         handleChange
     });
 
-    parcel.onChange(456);
+    parcel.set(456);
 
     let [newParcel, changeRequest] = handleChange.mock.calls[0];
 
@@ -21,7 +21,7 @@ test('Parcel.dispatch() should pass handleChange to newly created parcel', () =>
     expect(changeRequest.nextData.value).toBe(456);
     expect(changeRequest.prevData.value).toBe(123);
 
-    newParcel.onChange(789);
+    newParcel.set(789);
 
     let [newParcel2, changeRequest2] = handleChange.mock.calls[1];
 
@@ -145,9 +145,7 @@ test('Parcel.update(asChildNodes()) should call the Parcels handleChange functio
     expect(handleChange.mock.calls[0][0].data.value).toEqual([1,2,3,4]);
 });
 
-
-
-test('Parcel.onChange() should work like set that only accepts a single argument', () => {
+test('Parcel._setInput() should work like set but take the value from event.currentTarget.value', () => {
     expect.assertions(2);
 
     var data = {
@@ -173,43 +171,14 @@ test('Parcel.onChange() should work like set that only accepts a single argument
             expect(expectedData).toEqual(parcel.data);
             expect(expectedAction).toEqual(GetAction(changeRequest));
         }
-    }).onChange(456);
-});
-
-test('Parcel.onChangeDOM() should work like onChange but take the value from event.currentTarget.value', () => {
-    expect.assertions(2);
-
-    var data = {
-        value: 123
-    };
-
-    var expectedData = {
-        child: undefined,
-        meta: {},
-        value: 456,
-        key: '^'
-    };
-
-    var expectedAction = {
-        type: "set",
-        keyPath: [],
-        payload: 456
-    };
-
-    new Parcel({
-        ...data,
-        handleChange: (parcel, changeRequest) => {
-            expect(expectedData).toEqual(parcel.data);
-            expect(expectedAction).toEqual(GetAction(changeRequest));
-        }
-    }).onChangeDOM({
+    })._setInput({
         currentTarget: {
             value: 456
         }
     });
 });
 
-test('Parcel.onChangeDOMCheckbox() should work like onChange but take the value from event.currentTarget.checked', () => {
+test('Parcel._setCheckbox() should work like set but take the value from event.currentTarget.checked', () => {
 
     let handleChange = jest.fn();
 
@@ -218,7 +187,7 @@ test('Parcel.onChangeDOMCheckbox() should work like onChange but take the value 
         handleChange
     });
 
-    parcel.onChangeDOMCheckbox({
+    parcel._setCheckbox({
         currentTarget: {
             checked: true
         }

--- a/packages/dataparcels/src/parcel/__test__/ParcelGetMethods-test.js
+++ b/packages/dataparcels/src/parcel/__test__/ParcelGetMethods-test.js
@@ -2,7 +2,7 @@
 import Parcel from '../Parcel';
 import deleted from '../../parcelData/deleted';
 
-test('Parcel.spread() returns an object with value and onChange', () => {
+test('Parcel.spread() returns an object with value and set', () => {
     var data = {
         value: 123,
         handleChange: (parcel) => {
@@ -19,7 +19,7 @@ test('Parcel.spread() returns an object with value and onChange', () => {
     } = parcel.spread();
 
     expect(value).toBe(parcel.value);
-    expect(onChange).toBe(parcel.onChange);
+    expect(onChange).toBe(parcel.set);
 });
 
 test('Parcel.spread(notFoundValue) returns an object with notFoundValue', () => {
@@ -40,7 +40,7 @@ test('Parcel.spread(notFoundValue) returns an object with notFoundValue', () => 
     expect(parcel3.spread("???").value).toBe("123");
 });
 
-test('Parcel.spreadDOM() returns an object with value and onChange (onChangeDOM)', () => {
+test('Parcel.spreadInput() returns an object with value and onChange (_setInput)', () => {
     var data = {
         value: 123,
         handleChange: (parcel) => {
@@ -54,13 +54,13 @@ test('Parcel.spreadDOM() returns an object with value and onChange (onChangeDOM)
     const {
         value,
         onChange
-    } = parcel.spreadDOM();
+    } = parcel.spreadInput();
 
     expect(value).toBe(parcel.value);
-    expect(onChange).toBe(parcel.onChangeDOM);
+    expect(onChange).toBe(parcel._setInput);
 });
 
-test('Parcel.spreadDOM(notFoundValue) returns an object with notFoundValue', () => {
+test('Parcel.spreadInput(notFoundValue) returns an object with notFoundValue', () => {
     var parcel = new Parcel({
         value: undefined
     });
@@ -73,12 +73,12 @@ test('Parcel.spreadDOM(notFoundValue) returns an object with notFoundValue', () 
         value: "123"
     });
 
-    expect(parcel.spreadDOM("???").value).toBe("???");
-    expect(parcel2.spreadDOM("???").value).toBe("???");
-    expect(parcel3.spreadDOM("???").value).toBe("123");
+    expect(parcel.spreadInput("???").value).toBe("???");
+    expect(parcel2.spreadInput("???").value).toBe("???");
+    expect(parcel3.spreadInput("???").value).toBe("123");
 });
 
-test('Parcel.spreadDOMCheckbox() returns an object with checked and onChange (onChangeDOMCheckbox)', () => {
+test('Parcel.spreadCheckbox() returns an object with checked and onChange (_setCheckbox)', () => {
 
     var parcel = new Parcel({
         value: true
@@ -87,13 +87,13 @@ test('Parcel.spreadDOMCheckbox() returns an object with checked and onChange (on
     const {
         checked,
         onChange
-    } = parcel.spreadDOMCheckbox();
+    } = parcel.spreadCheckbox();
 
     expect(checked).toBe(parcel.value);
-    expect(onChange).toBe(parcel.onChangeDOMCheckbox);
+    expect(onChange).toBe(parcel._setCheckbox);
 });
 
-test('Parcel.spreadDOMCheckbox(notFoundValue) returns an object with cast boolean / notFoundValue', () => {
+test('Parcel.spreadCheckbox(notFoundValue) returns an object with cast boolean / notFoundValue', () => {
     var parcel = new Parcel({
         value: undefined
     });
@@ -102,9 +102,9 @@ test('Parcel.spreadDOMCheckbox(notFoundValue) returns an object with cast boolea
         value: "123"
     });
 
-    expect(parcel.spreadDOMCheckbox().checked).toBe(false);
-    expect(parcel.spreadDOMCheckbox(true).checked).toBe(true);
-    expect(parcel.spreadDOMCheckbox(false).checked).toBe(false);
+    expect(parcel.spreadCheckbox().checked).toBe(false);
+    expect(parcel.spreadCheckbox(true).checked).toBe(true);
+    expect(parcel.spreadCheckbox(false).checked).toBe(false);
 });
 
 test('Parcel.spy() should be called with parcel', () => {
@@ -140,7 +140,7 @@ test('Parcel.spyChange() should be called with changeRequest', () => {
         .spyChange(spy)
         .get('abc')
         .spyChange(spy2)
-        .onChange(456);
+        .set(456);
 
     expect(spy2.mock.calls[0][0].nextData.value).toEqual(456);
     expect(spy.mock.calls[0][0].nextData.value).toEqual({abc: 456});

--- a/packages/dataparcels/src/parcel/__test__/ParentGetMethods-test.js
+++ b/packages/dataparcels/src/parcel/__test__/ParentGetMethods-test.js
@@ -69,7 +69,7 @@ test('ParentParcel.get(key) should return a new child Parcel', () => {
 
     expect(childParcel instanceof Parcel).toBe(true);
     expect(childParcel.value).toBe(1);
-    childParcel.onChange(2);
+    childParcel.set(2);
 });
 
 test('ParentParcel.get(key).value should return the same instance of the nested piece of data', () => {
@@ -123,7 +123,7 @@ test('ParentParcel.get(key).key on array should return the key, not the index', 
     expect(new Parcel(data).get(0).key).toBe("#a");
 });
 
-test('ParentParcel.get(key).get(key) should return a new child Parcel and chain onChanges', () => {
+test('ParentParcel.get(key).get(key) should return a new child Parcel and chain sets', () => {
     expect.assertions(4);
 
     var data = {
@@ -156,7 +156,7 @@ test('ParentParcel.get(key).get(key) should return a new child Parcel and chain 
 
     expect(childParcel instanceof Parcel).toBe(true);
     expect(childParcel.value).toBe(2);
-    childParcel.onChange(6);
+    childParcel.set(6);
 });
 
 test('ParentParcel.get(keyDoesntExist) should return a parcel with value of undefined', () => {
@@ -214,7 +214,7 @@ test('ParentParcel.get() should cache its parcelData.child after its calculated,
 
     expect(ms / 10).toBeGreaterThan(ms2); // expect amazing performance boosts from having cached
 
-    parcel.get(0).onChange(123);
+    parcel.get(0).set(123);
 });
 
 test('ParentParcel.getIn(keyPath) should return a new descendant Parcel', () => {
@@ -254,7 +254,7 @@ test('ParentParcel.getIn(keyPath) should return a new descendant Parcel', () => 
 
     expect(descendantParcel instanceof Parcel).toBe(true);
     expect(descendantParcel.value).toBe(123);
-    descendantParcel.onChange(456);
+    descendantParcel.set(456);
 });
 
 test('ParentParcel.getIn(keyPath) should cope with non existent keypaths', () => {

--- a/packages/react-dataparcels/src/deprecated/__test__/ParcelBoundaryDeprecated-test.js
+++ b/packages/react-dataparcels/src/deprecated/__test__/ParcelBoundaryDeprecated-test.js
@@ -36,7 +36,7 @@ test('ParcelBoundary should send correct changes back up when debounce = 0', () 
     </ParcelBoundary>);
 
     let childParcel = childRenderer.mock.calls[0][0];
-    childParcel.onChange(123);
+    childParcel.set(123);
     expect(handleChange).toHaveBeenCalledTimes(1);
     let newParcel = handleChange.mock.calls[0][0];
     expect(newParcel.value).toBe(123);
@@ -156,7 +156,7 @@ test('ParcelBoundary should release changes when called', async () => {
     </ParcelBoundary>);
 
     let childParcel = childRenderer.mock.calls[0][0];
-    childParcel.onChange(123);
+    childParcel.set(123);
     // handleChange shouldn't be called yet because hold is true
     expect(handleChange).toHaveBeenCalledTimes(0);
 
@@ -191,7 +191,7 @@ test('ParcelBoundary should use onRelease', async () => {
     </ParcelBoundary>);
 
     let childParcel = childRenderer.mock.calls[0][0];
-    childParcel.onChange(123);
+    childParcel.set(123);
     wrapper.update();
 
     // call release, then onRelease1 should have been called but no others
@@ -229,7 +229,7 @@ test('ParcelBoundary should cancel changes when called', async () => {
     </ParcelBoundary>);
 
     let childParcel = childRenderer.mock.calls[0][0];
-    childParcel.onChange(123);
+    childParcel.set(123);
     // handleChange shouldn't be called yet because hold is true
     expect(handleChange).toHaveBeenCalledTimes(0);
 
@@ -268,7 +268,7 @@ test('ParcelBoundary should onCancel', async () => {
     </ParcelBoundary>);
 
     let childParcel = childRenderer.mock.calls[0][0];
-    childParcel.onChange(123);
+    childParcel.set(123);
     wrapper.update();
     let childRendererCalls = childRenderer.mock.calls.length;
 
@@ -330,7 +330,7 @@ test('ParcelBoundary should pass buffer info to childRenderer', async () => {
     </ParcelBoundary>);
 
     let [childParcel, control] = childRenderer.mock.calls[0];
-    childParcel.onChange(123);
+    childParcel.set(123);
     // handleChange shouldn't be called yet because hold is true
     expect(control.buffered).toBe(false);
     expect(control.buffer.length).toBe(0);
@@ -363,7 +363,7 @@ test('ParcelBoundary should debounce', async () => {
     let childParcel = childRenderer.mock.calls[0][0];
 
     // make a change with a value
-    childParcel.get('a').onChange(123);
+    childParcel.get('a').set(123);
 
     // handleChange shouldn't be called yet
     expect(handleChange).toHaveBeenCalledTimes(0);
@@ -381,7 +381,7 @@ test('ParcelBoundary should debounce', async () => {
     expect(childParcel2.value).toEqual({a:123, b:2});
 
     // make another change with a value
-    childParcel2.get('a').onChange(456);
+    childParcel2.get('a').set(456);
 
     // wait another 20ms
     jest.advanceTimersByTime(20);
@@ -396,8 +396,8 @@ test('ParcelBoundary should debounce', async () => {
     expect(childParcel3.value).toEqual({a:456, b:2});
 
     // make another 2 changes with a value
-    childParcel3.get('a').onChange(789);
-    childParcel3.get('b').onChange(789);
+    childParcel3.get('a').set(789);
+    childParcel3.get('b').set(789);
 
     // wait another 40ms - with an interval this big, debounce should have finally had time to kick in
     jest.advanceTimersByTime(40);
@@ -426,7 +426,7 @@ test('ParcelBoundary should cancel unreleased changes when receiving a new parce
     </ParcelBoundary>);
 
     let childParcel = childRenderer.mock.calls[0][0];
-    childParcel.onChange(789);
+    childParcel.set(789);
 
     let childParcel2 = childRenderer.mock.calls[1][0];
 
@@ -464,7 +464,7 @@ test('ParcelBoundary should not update value from props for updates caused by th
     </ParcelBoundary>);
 
     let childParcel = childRenderer.mock.calls[0][0];
-    childParcel.onChange(456);
+    childParcel.set(456);
 
     let newParcel = handleChange.mock.calls[0][0];
     newParcel._frameMeta = {
@@ -513,7 +513,7 @@ test('ParcelBoundary should update meta from props for updates caused by themsel
     </ParcelBoundary>);
 
     let childParcel = childRenderer.mock.calls[0][0];
-    childParcel.onChange(456);
+    childParcel.set(456);
 
     let newParcel = handleChange.mock.calls[0][0];
     newParcel._frameMeta = {
@@ -580,7 +580,7 @@ test('ParcelBoundary should pass changes through modifyBeforeUpdate', () => {
     </ParcelBoundary>);
 
     let childParcel = childRenderer.mock.calls[0][0];
-    childParcel.onChange(123);
+    childParcel.set(123);
     expect(handleChange).toHaveBeenCalledTimes(1);
     let newParcel = handleChange.mock.calls[0][0];
     expect(newParcel.value).toBe(125);
@@ -652,7 +652,7 @@ test('ParcelBoundary should accept a debugParcel boolean and log about parcel ch
     </ParcelBoundary>);
 
     let childParcel = childRenderer.mock.calls[0][0];
-    childParcel.onChange(123);
+    childParcel.set(123);
 
     expect(console.log.mock.calls[2][0]).toBe("ParcelBoundary: Parcel changed:");
     // $FlowFixMe
@@ -702,7 +702,7 @@ test('ParcelBoundary should accept a debugParcel boolean and log about cancellin
     </ParcelBoundary>);
 
     let childParcel = childRenderer.mock.calls[0][0];
-    childParcel.onChange(123);
+    childParcel.set(123);
 
     wrapper.update();
 
@@ -728,7 +728,7 @@ test('ParcelBoundary should accept a debugBuffer boolean and log about adding to
     </ParcelBoundary>);
 
     let childParcel = childRenderer.mock.calls[0][0];
-    childParcel.onChange(123);
+    childParcel.set(123);
 
     expect(console.log.mock.calls[0][0]).toBe("ParcelBoundary: Add to buffer:");
     // $FlowFixMe
@@ -750,7 +750,7 @@ test('ParcelBoundary should accept a debugBuffer boolean and log about releasing
     </ParcelBoundary>);
 
     let childParcel = childRenderer.mock.calls[0][0];
-    childParcel.onChange(123);
+    childParcel.set(123);
 
     wrapper.update();
 
@@ -777,7 +777,7 @@ test('ParcelBoundary should accept a debugBuffer boolean and log about cancellin
     </ParcelBoundary>);
 
     let childParcel = childRenderer.mock.calls[0][0];
-    childParcel.onChange(123);
+    childParcel.set(123);
 
     wrapper.update();
 

--- a/packages/react-dataparcels/src/deprecated/__test__/ParcelHoc-test.js
+++ b/packages/react-dataparcels/src/deprecated/__test__/ParcelHoc-test.js
@@ -39,7 +39,7 @@ test('ParcelHoc changes should be put back into ParcelHoc state', () => {
 
     let wrapper = shallow(<Hocked />);
     let {proppy} = wrapper.props();
-    proppy.onChange(456);
+    proppy.set(456);
     expect(456).toBe(wrapper.update().props().proppy.value);
 });
 
@@ -54,13 +54,13 @@ test('ParcelHoc config should accept an onChange function, and call it with the 
     let onChange = jest.fn();
     let wrapper = shallow(<Hocked onChange={onChange} />);
     let {proppy} = wrapper.props();
-    proppy.onChange(456);
+    proppy.set(456);
 
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange.mock.calls[0][0]).toBe(456);
 
     // dont call onChange if the value hasnt changed
-    wrapper.update().props().proppy.onChange(456);
+    wrapper.update().props().proppy.set(456);
     expect(onChange).toHaveBeenCalledTimes(1);
 });
 
@@ -204,7 +204,7 @@ test('ParcelHoc modifyBeforeUpdate should be called when change occurs', () => {
     );
 
     let childProps = wrapper.props();
-    childProps.proppy.onChange(456);
+    childProps.proppy.set(456);
 
     // child parcel should contain value after having been passed through modifyBeforeUpdate
     expect(wrapper.update().props().proppy.value).toBe(458);
@@ -224,7 +224,7 @@ test('ParcelHoc modifyBeforeUpdate should be called when relevant prop change oc
     );
 
     let childProps = wrapper.props();
-    childProps.proppy.onChange(456);
+    childProps.proppy.set(456);
 
     // child parcel should contain value after having been passed through modifyBeforeUpdate
     expect(wrapper.update().props().proppy.value).toBe(458);


### PR DESCRIPTION
*Please ignore failing docs build, this will be amended in a future PR to the release/strict-swift release branch*

Goal of this PR is to:
- contain usages of the name "onChange" to only be used by spread methods. The only reason the "onChange" name exists is because thats what React uses, but the identical method "set" aligns with the rest of the parcel API much more strongly.
- Remove any usage of the ill-fitting term "DOM" when describing onChange functions that get passed directly to React inputs and checkboxes.
- Remove rarely used functions that still have accessible equivalents

## dataparcels
- **BREAKING CHANGE** `parcel.spreadDOM()` is now `parcel.spreadInput()`
- **BREAKING CHANGE** `parcel.spreadDOMCheckbox()` is now `parcel.spreadCheckbox()`
- **BREAKING CHANGE** `parcel.onChange()` has been removed
  - Use `parcel.set()` instead
- **BREAKING CHANGE** `parcel.onChangeDOM()` has been removed
  - Using this function directly is rare, as the whole point of the DOM functions was to easily and automatically bind React form inputs to parcels. I've never hit the use case of wanting parcels to handle getting the value out of the change event from an input, but not also wanting the spreading of the `value` and `onChange`. But if you require this, you can use `parcel.spreadInput().onChange`
- **BREAKING CHANGE** `parcel. onChangeDOMCheckbox()` has been removed
  - Using this function directly is rare, as the whole point of the DOM functions was to easily and automatically bind React form inputs to parcels. I've never hit the use case of wanting parcels to handle getting the value out of the change event from an input, but not also wanting the spreading of the `value` and `onChange`. But if you require this, you can use `parcel.spreadInput(). onChangeDOMCheckbox `

## To upgrade

- Replace `spreadDOM()` with `spreadInput()`
- Replace `spreadDOMCheckbox()` with `spreadCheckbox()`
- Replace `.onChange` with `.set(`
- Replace `.onChangeDOM` with `.spreadInput().onChange`
- Replace `.onChangeDOMCheckbox` with `.spreadCheckbox().onChange`