### PR TITLE
Feature/fix parcel node

### DIFF
--- a/packages/dataparcels/.size-limit.json
+++ b/packages/dataparcels/.size-limit.json
@@ -20,11 +20,11 @@
         "path": "deleted.js"
     },
     {
-        "limit": "5.8 KB",
+        "limit": "5.6 KB",
         "path": "ParcelNode.js"
     },
     {
-        "limit": "6.2 KB",
+        "limit": "5.9 KB",
         "path": "asNode.js"
     },
     {
@@ -36,7 +36,7 @@
         "path": "asRaw.js"
     },
     {
-        "limit": "6.3 KB",
+        "limit": "6.1 KB",
         "path": "translate.js"
     },
     {

--- a/packages/dataparcels/src/modifiers/translate.js
+++ b/packages/dataparcels/src/modifiers/translate.js
@@ -1,11 +1,12 @@
 // @flow
 import type Parcel from '../parcel/Parcel';
+import type ChangeRequest from '../change/ChangeRequest';
 
 import asNode from '../parcelNode/asNode';
 
 type Config = {
-    down?: Function,
-    up?: Function,
+    down?: (value: any) => any,
+    up?: (value: any, changeRequest: ChangeRequest) => any,
     preserveInput?: boolean
 };
 
@@ -29,7 +30,7 @@ export default (config: Config) => {
             }
             return node.update(down);
         }))
-        .modifyUp(asNode(node => {
+        .modifyUp(asNode((node) => {
             return node
                 .update(up)
                 .setMeta({

--- a/packages/dataparcels/src/parcelNode/ParcelNode.js
+++ b/packages/dataparcels/src/parcelNode/ParcelNode.js
@@ -3,20 +3,13 @@ import type {Index} from '../types/Types';
 import type {Key} from '../types/Types';
 import type {ParcelData} from '../types/Types';
 import type {ParcelMeta} from '../types/Types';
+import type ChangeRequest from '../change/ChangeRequest';
 
-import isParentValue from '../parcelData/isParentValue';
-import isIndexedValue from '../parcelData/isIndexedValue';
 import keyOrIndexToKey from '../parcelData/keyOrIndexToKey';
 import prepareChildKeys from '../parcelData/prepareChildKeys';
-import parcelSetSelf from '../parcelData/setSelf';
 import parcelGet from '../parcelData/get';
 import setMeta from '../parcelData/setMeta';
-import updateChild from '../parcelData/updateChild';
-import updateChildKeys from '../parcelData/updateChildKeys';
-
-import map from 'unmutable/map';
-import pipeWith from 'unmutable/pipeWith';
-import shallowToJS from 'unmutable/shallowToJS';
+import prepUpdater from '../parcelData/prepUpdater';
 
 export default class ParcelNode {
     constructor(value: any) {
@@ -32,6 +25,7 @@ export default class ParcelNode {
     _parent: ?ParcelNode;
     _parcelData: ?ParcelData;
     _key: Key;
+    _changeRequest: ?ChangeRequest;
 
     //
     // private methods
@@ -95,70 +89,8 @@ export default class ParcelNode {
     };
 
     update = (updater: Function): ParcelNode => {
-        let {data, value} = this;
-        if(isParentValue(value)) {
-            this._prepareChildKeys();
-            value = pipeWith(
-                value,
-                map((value, key) => this.get(key))
-            );
-        }
-
-        let updated: any = updater(value);
-
         let parcelNode = new ParcelNode();
-        if(!isParentValue(updated)) {
-            parcelNode._parcelData = parcelSetSelf(updated)(data);
-            return parcelNode;
-        }
-
-        updated = pipeWith(
-            updated,
-            map((maybeNode: any) => maybeNode instanceof ParcelNode
-                ? maybeNode
-                : new ParcelNode(maybeNode)
-            )
-        );
-
-        let newValue = map(node => node.value)(updated);
-
-        let hasNewNode = false;
-        let keyMap = {};
-
-        let newChild = pipeWith(
-            updated,
-            shallowToJS(),
-            map(node => {
-                let {child, meta, key} = node.data;
-
-                let keyExists = keyMap[key];
-                keyMap[key] = true;
-                if(keyExists || node._parent !== this) {
-                    hasNewNode = true;
-                    key = undefined;
-                }
-
-                return {child, meta, key};
-            })
-        );
-
-        let newParcelData: ParcelData = {
-            ...data,
-            value: newValue,
-            child: newChild
-        };
-
-        let typeChanged = () => isIndexedValue(value) !== isIndexedValue(updated);
-
-        if(hasNewNode || typeChanged()) {
-            newParcelData = pipeWith(
-                newParcelData,
-                updateChild(),
-                updateChildKeys(data.child)
-            );
-        }
-
-        parcelNode._parcelData = newParcelData;
+        parcelNode._parcelData = prepUpdater(updater)(this._parcelData, this._changeRequest);
         return parcelNode;
     };
 

--- a/packages/dataparcels/src/parcelNode/__test__/ParcelNode-test.js
+++ b/packages/dataparcels/src/parcelNode/__test__/ParcelNode-test.js
@@ -93,55 +93,16 @@ test('ParcelNodes should update() non-parent values and keep meta and key', () =
     expect(result.key).toBe('aaa');
 });
 
-test('ParcelNodes should update() parent values to non-parent values', () => {
-    let node = new ParcelNode([1,2,3]);
-    let result = node.update(value => value.map(node => node.value).join(", "));
-    expect(result.value).toBe('1, 2, 3');
-});
+test('ParcelNodes should update() parent values without replacing children with nodes', () => {
+    let node = new ParcelNode();
+    node._parcelData = {
+        value: [1,2,3]
+    };
 
-test('ParcelNodes should update() parent values', () => {
-    let node = new ParcelNode([1,2,3]);
-    let result = node.update(reverse());
-    expect(result.value).toEqual([3,2,1]);
-    expect(result.get('#a').value).toBe(1);
-});
+    let updater = jest.fn(value => value);
 
-test('ParcelNodes should update() parent values changing type', () => {
-    let node = new ParcelNode({foo: 'bar', baz: 'qux'});
-    let result = node.update(toArray());
-    expect(result.value).toEqual(['bar', 'qux']);
-    // keys should have been recalculated
-    expect(result.get('#a').value).toBe('bar');
-});
+    let result = node.update(updater);
 
-test('ParcelNodes should update() parent values adding a new ParcelNode', () => {
-    let node = new ParcelNode([1,2,3]);
-    let result = node.update(arr => [...arr, new ParcelNode(4)]);
-    expect(result.value).toEqual([1,2,3,4]);
-    expect(result.get('#d').value).toBe(4);
-});
-
-test('ParcelNodes should update() parent values adding a new non-ParcelNode', () => {
-    let node = new ParcelNode([1,2,3]);
-    let result = node.update(arr => [...arr, 4]);
-    expect(result.value).toEqual([1,2,3,4]);
-    expect(result.get('#d').value).toBe(4);
-});
-
-test('ParcelNodes should update() parent values adding duplicated ParcelNodes', () => {
-    let node = new ParcelNode([1,2,3]);
-    let result = node.update(arr => [...arr, ...arr]);
-    expect(result.value).toEqual([1,2,3,1,2,3]);
-    expect(result.get('#d').value).toBe(1);
-    expect(result.get('#e').value).toBe(2);
-    expect(result.get('#f').value).toBe(3);
-});
-
-test('ParcelNodes should update() parent values adding ParcelNodes from other parcelnodes', () => {
-    let node = new ParcelNode([1,2,[3],4,5]);
-    let grandchild = node.get(2).get(0); // will have a value of 3
-    let result = node.update(arr => [arr[3], grandchild]);
-    expect(result.value).toEqual([4,3]);
-    expect(result.get(0).key).toBe('#d');
-    expect(result.get(1).key).toBe('#f');
+    expect(updater).toHaveBeenCalledTimes(1);
+    expect(updater.mock.calls[0][0]).toEqual([1,2,3]);
 });

--- a/packages/dataparcels/src/parcelNode/__test__/asChildNodes-test.js
+++ b/packages/dataparcels/src/parcelNode/__test__/asChildNodes-test.js
@@ -1,0 +1,102 @@
+// @flow
+import asChildNodes from '../asChildNodes';
+import ParcelNode from '../ParcelNode';
+import reverse from 'unmutable/reverse';
+import toArray from 'unmutable/toArray';
+
+test('asChildNodes should accept updater', () => {
+    let parcelData = {
+        value: 123,
+        meta: {
+            foo: true
+        }
+    };
+
+    expect(asChildNodes(value => value)(parcelData)).toEqual(parcelData);
+});
+
+test('asChildNodes should update non-parent values', () => {
+    let parcelData = {
+        value: 100
+    };
+    let result = asChildNodes(value => value + 200)(parcelData);
+    expect(result.value).toBe(300);
+});
+
+test('asChildNodes should update non-parent values and keep meta and key', () => {
+    let parcelData = {
+        value: 100,
+        meta: {foo: true},
+        key: 'aaa'
+    };
+
+    let result = asChildNodes(value => value + 200)(parcelData);
+
+    expect(result.value).toBe(300);
+    expect(result.meta).toEqual({foo: true});
+    expect(result.key).toBe('aaa');
+});
+
+test('asChildNodes should update parent values to non-parent values', () => {
+    let parcelData = {
+        value: [1,2,3]
+    };
+
+    let result = asChildNodes(value => value.map(node => node.value).join(", "))(parcelData);
+    expect(result.value).toBe('1, 2, 3');
+});
+
+test('asChildNodes should update parent values', () => {
+    let parcelData = {
+        value: [1,2,3]
+    };
+
+    let result = asChildNodes(reverse())(parcelData);
+
+    expect(result.value).toEqual([3,2,1]);
+    expect(result.child[2].key).toBe('#a');
+});
+
+test('asChildNodes should update parent values changing type', () => {
+    let parcelData = {
+        value: {foo: 'bar', baz: 'qux'}
+    };
+
+    let result = asChildNodes(toArray())(parcelData);
+
+    expect(result.value).toEqual(['bar', 'qux']);
+    // keys should have been recalculated
+    expect(result.child[0].key).toBe('#a');
+});
+
+test('asChildNodes should update parent values adding a new ParcelNode', () => {
+    let parcelData = {
+        value: [1,2,3]
+    };
+
+    let result = asChildNodes(arr => [...arr, new ParcelNode(4)])(parcelData);
+    expect(result.value).toEqual([1,2,3,4]);
+    expect(result.child[3].key).toBe('#d');
+});
+
+test('asChildNodes should update parent values adding a new non-ParcelNode', () => {
+    let parcelData = {
+        value: [1,2,3]
+    };
+
+    let result = asChildNodes(arr => [...arr, 4])(parcelData);
+    expect(result.value).toEqual([1,2,3,4]);
+    expect(result.child[3].key).toBe('#d');
+});
+
+test('asChildNodes should update parent values adding duplicated ParcelNodes', () => {
+    let parcelData = {
+        value: [1,2,3]
+    };
+
+    let result = asChildNodes(arr => [...arr, ...arr])(parcelData);
+    expect(result.value).toEqual([1,2,3,1,2,3]);
+    expect(result.child[3].key).toBe('#d');
+    expect(result.child[4].key).toBe('#e');
+    expect(result.child[5].key).toBe('#f');
+});

--- a/packages/dataparcels/src/parcelNode/asChildNodes.js
+++ b/packages/dataparcels/src/parcelNode/asChildNodes.js
@@ -47,16 +47,14 @@ const updateChildNodes = (node: ParcelNode, updater: Function, changeRequest: *)
     let newChild = pipeWith(
         updated,
         shallowToJS(),
-        map(node => {
-            let {child, meta, key} = node.data;
-
+        map(childNode => {
+            let {child, meta, key} = childNode.data;
             let keyExists = keyMap[key];
             keyMap[key] = true;
-            if(keyExists || node._parent !== node) {
+            if(keyExists || childNode._parent !== node) {
                 hasNewNode = true;
                 key = undefined;
             }
-
             return {child, meta, key};
         })
     );

--- a/packages/dataparcels/src/parcelNode/asChildNodes.js
+++ b/packages/dataparcels/src/parcelNode/asChildNodes.js
@@ -1,7 +1,88 @@
 // @flow
+import type {ParcelData} from '../types/Types';
+
+import isParentValue from '../parcelData/isParentValue';
+import isIndexedValue from '../parcelData/isIndexedValue';
+import parcelSetSelf from '../parcelData/setSelf';
+import updateChild from '../parcelData/updateChild';
+import updateChildKeys from '../parcelData/updateChildKeys';
+import ParcelNode from './ParcelNode';
+
+import map from 'unmutable/map';
+import pipeWith from 'unmutable/pipeWith';
+import shallowToJS from 'unmutable/shallowToJS';
 import asNode from './asNode';
+
+const updateChildNodes = (node: ParcelNode, updater: Function, changeRequest: *): ParcelNode => {
+    let {data, value} = node;
+    if(isParentValue(value)) {
+        node._prepareChildKeys();
+        value = pipeWith(
+            value,
+            map((value, key) => node.get(key))
+        );
+    }
+
+    let updated: any = updater(value, changeRequest);
+
+    let parcelNode = new ParcelNode();
+    if(!isParentValue(updated)) {
+        parcelNode._parcelData = parcelSetSelf(updated)(data);
+        return parcelNode;
+    }
+
+    updated = pipeWith(
+        updated,
+        map((maybeNode: any) => maybeNode instanceof ParcelNode
+            ? maybeNode
+            : new ParcelNode(maybeNode)
+        )
+    );
+
+    let newValue = map(node => node.value)(updated);
+
+    let hasNewNode = false;
+    let keyMap = {};
+
+    let newChild = pipeWith(
+        updated,
+        shallowToJS(),
+        map(node => {
+            let {child, meta, key} = node.data;
+
+            let keyExists = keyMap[key];
+            keyMap[key] = true;
+            if(keyExists || node._parent !== node) {
+                hasNewNode = true;
+                key = undefined;
+            }
+
+            return {child, meta, key};
+        })
+    );
+
+    let newParcelData: ParcelData = {
+        ...data,
+        value: newValue,
+        child: newChild
+    };
+
+    let typeChanged = () => isIndexedValue(value) !== isIndexedValue(updated);
+
+    if(hasNewNode || typeChanged()) {
+        newParcelData = pipeWith(
+            newParcelData,
+            updateChild(),
+            updateChildKeys(data.child)
+        );
+    }
+
+    parcelNode._parcelData = newParcelData;
+    return parcelNode;
+};
+
 export default (updater: Function) => {
-    let fn = asNode(node => node.update(updater));
+    let fn = asNode((node, changeRequest) => updateChildNodes(node, updater, changeRequest));
     fn._updater = updater;
     return fn;
 };

--- a/packages/dataparcels/src/parcelNode/asNode.js
+++ b/packages/dataparcels/src/parcelNode/asNode.js
@@ -6,10 +6,11 @@ import asRaw from '../parcelData/asRaw';
 import ParcelNode from './ParcelNode';
 
 export default (updater: Function): Function => {
-    let fn = (parcelData: ParcelData): ParcelData => {
+    let fn = (parcelData: ParcelData, changeRequest: *): ParcelData => {
         let parcelNode = new ParcelNode();
         parcelNode._parcelData = parcelData;
-        let result = updater(parcelNode);
+        parcelNode._changeRequest = changeRequest;
+        let result = updater(parcelNode, changeRequest);
         if(!(result instanceof ParcelNode)) {
             throw AsNodeReturnNonParcelNodeError();
         }

--- a/packages/react-dataparcels/.size-limit.json
+++ b/packages/react-dataparcels/.size-limit.json
@@ -20,11 +20,11 @@
         "path": "deleted.js"
     },
     {
-        "limit": "5.8 KB",
+        "limit": "5.6 KB",
         "path": "ParcelNode.js"
     },
     {
-        "limit": "6.2 KB",
+        "limit": "5.9 KB",
         "path": "asNode.js"
     },
     {
@@ -36,7 +36,7 @@
         "path": "asRaw.js"
     },
     {
-        "limit": "6.3 KB",
+        "limit": "6.1 KB",
         "path": "translate.js"
     },
     {


### PR DESCRIPTION
- fix: let parcelNode.update use any updater type

Previously the docs said `parcelNode.update()` would work with any updater type (e.g. `asNode`, etc), but it was only working with straight values. Fixed this by using `prepUpdater`.

Also moved out the logic to handle updating child nodes to the `asChildNode` file,
which is the only file that needs that logic. This should also help keep bundle sizes lower
